### PR TITLE
Add VS Code section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ An MCP server that provides a tool for sending transactional emails via Mailtrap
 
 ### Claude Desktop or Cursor
 
-Edit the Claude Desktop configuration file:
-
-**Mac**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-
-**Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-
 Add the following configuration:
 
 ```json
@@ -54,7 +48,23 @@ If you are using `asdf` for managing Node.js you must use absolute path to execu
 }
 ```
 
+#### Claude Desktop config file location
+
+**Mac**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+**Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+#### Cursor config file location
+
+**Mac**: `~/.cursor/mcp.json`
+
+**Windows**: `%USERPROFILE%\.cursor\mcp.json`
+
 ### VS Code
+
+Run in Command Palette: `Preferences: Open User Settings (JSON)`
+
+Then, in the settings file, add the following configuration:
 
 ```json
 {
@@ -117,11 +127,8 @@ npm install
 
 ### Configuration with Claude Desktop or Cursor
 
-Edit the Claude Desktop configuration file:
-
-**Mac**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-
-**Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+> [!TIP]
+> See the location of the config file in the [Setup](#setup) section.
 
 Add the following configuration:
 
@@ -164,6 +171,9 @@ If you are using `asdf` for managing Node.js you should use absolute path to exe
 ```
 
 ### VS Code
+
+> [!TIP]
+> See the location of the config file in the [Setup](#setup) section.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An MCP server that provides a tool for sending transactional emails via Mailtrap
 
 ## Setup
 
-### Claude Desktop
+### Claude Desktop or Cursor
 
 Edit the Claude Desktop configuration file:
 
@@ -54,6 +54,28 @@ If you are using `asdf` for managing Node.js you must use absolute path to execu
 }
 ```
 
+### VS Code
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "mailtrap": {
+        "command": "npx",
+        "args": ["-y", "mcp-mailtrap"],
+        "env": {
+          "MAILTRAP_API_TOKEN": "your_mailtrap_api_token",
+          "DEFAULT_FROM_EMAIL": "your_sender@example.com"
+        }
+      }
+    }
+  }
+}
+```
+
+> [!TIP]
+> Don't forget to restart your MCP server after changing the "env" section.
+
 ## Usage
 
 Once configured, you can ask agent to send emails, for example:
@@ -93,7 +115,7 @@ cd mailtrap-mcp
 npm install
 ```
 
-### Configuration with Claude Desktop
+### Configuration with Claude Desktop or Cursor
 
 Edit the Claude Desktop configuration file:
 
@@ -135,6 +157,25 @@ If you are using `asdf` for managing Node.js you should use absolute path to exe
         "ASDF_NODEJS_VERSION": "20.6.1",
         "MAILTRAP_API_TOKEN": "your_mailtrap_api_token",
         "DEFAULT_FROM_EMAIL": "your_sender@example.com"
+      }
+    }
+  }
+}
+```
+
+### VS Code
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "mailtrap": {
+        "command": "node",
+        "args": ["/path/to/mailtrap-mcp/dist/index.js"],
+        "env": {
+          "MAILTRAP_API_TOKEN": "your_mailtrap_api_token",
+          "DEFAULT_FROM_EMAIL": "your_sender@example.com"
+        }
       }
     }
   }


### PR DESCRIPTION
## Motivation

Mention Cursor and VS Code in README since they are both very popular AI code editors

## Changes

- Add VS Code section to README
- Mention Cursor in README (since its config file has the same format as one of Claude Desktop)

## How to test

Already been successfully tested in both editors
