### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 An MCP server that provides a tool for sending transactional emails via Mailtrap
 
+<a href="https://glama.ai/mcp/servers/@railsware/mailtrap-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@railsware/mailtrap-mcp/badge" alt="Mailtrap Email Sending MCP server" />
+</a>
+
 ## Setup
 
 ### Claude Desktop or Cursor


### PR DESCRIPTION
This PR adds a badge for the [Mailtrap Email Sending](https://glama.ai/mcp/servers/@railsware/mailtrap-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@railsware/mailtrap-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@railsware/mailtrap-mcp/badge" alt="Mailtrap Email Sending MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.