### PR TITLE
Add Email Template tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,50 @@ Sends a transactional email through Mailtrap.
 - `bcc` (optional): Array of BCC recipient email addresses
 - `category` (optional): Email category for tracking
 
+### list-email-templates
+
+Retrieves email templates for a specific account.
+
+**Parameters:**
+
+- `accountId` (required): Mailtrap account identifier
+
+### create-email-template
+
+Creates a new email template.
+
+**Parameters:**
+
+- `accountId` (required): Mailtrap account identifier
+- `name` (required): Template name
+- `subject` (required): Template subject
+- `category` (required): Template category
+- `body_text` (optional): Text version of the template
+- `body_html` (optional): HTML version of the template
+
+### update-email-template
+
+Updates an existing email template.
+
+**Parameters:**
+
+- `accountId` (required): Mailtrap account identifier
+- `emailTemplateId` (required): Template ID
+- `name` (optional): Template name
+- `subject` (optional): Template subject
+- `category` (optional): Template category
+- `body_text` (optional): Text version of the template
+- `body_html` (optional): HTML version of the template
+
+### delete-email-template
+
+Deletes an email template.
+
+**Parameters:**
+
+- `accountId` (required): Mailtrap account identifier
+- `emailTemplateId` (required): Template ID
+
 ## Development
 
 1. Clone the repository:

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -1,0 +1,17 @@
+import axios from "axios";
+
+const { MAILTRAP_API_TOKEN } = process.env;
+
+if (!MAILTRAP_API_TOKEN) {
+  console.error("Error: MAILTRAP_API_TOKEN environment variable is required");
+  process.exit(1);
+}
+
+const apiClient = axios.create({
+  baseURL: "https://mailtrap.io",
+  headers: {
+    Authorization: `Bearer ${MAILTRAP_API_TOKEN}`,
+  },
+});
+
+export default apiClient;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,16 @@ import dotenv from "dotenv";
 import CONFIG from "./config";
 
 import { sendEmailSchema, sendEmail } from "./tools/sendEmail";
+import {
+  listEmailTemplatesSchema,
+  createEmailTemplateSchema,
+  updateEmailTemplateSchema,
+  deleteEmailTemplateSchema,
+  listEmailTemplates,
+  createEmailTemplate,
+  updateEmailTemplate,
+  deleteEmailTemplate,
+} from "./tools/templates";
 
 dotenv.config();
 
@@ -19,6 +29,34 @@ server.tool(
   "Send transactional email using Mailtrap",
   sendEmailSchema,
   sendEmail
+);
+
+server.tool(
+  "list-email-templates",
+  "List email templates for an account",
+  listEmailTemplatesSchema,
+  listEmailTemplates
+);
+
+server.tool(
+  "create-email-template",
+  "Create Email Template",
+  createEmailTemplateSchema,
+  createEmailTemplate
+);
+
+server.tool(
+  "update-email-template",
+  "Update Email Template",
+  updateEmailTemplateSchema,
+  updateEmailTemplate
+);
+
+server.tool(
+  "delete-email-template",
+  "Delete Email Template",
+  deleteEmailTemplateSchema,
+  deleteEmailTemplate
 );
 
 async function main() {

--- a/src/tools/templates/__tests__/templates.test.ts
+++ b/src/tools/templates/__tests__/templates.test.ts
@@ -1,0 +1,114 @@
+jest.mock("../../../apiClient", () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+    patch: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+import {
+  listEmailTemplates,
+  createEmailTemplate,
+  updateEmailTemplate,
+  deleteEmailTemplate,
+} from "../templates";
+import apiClient from "../../../apiClient";
+
+describe("email templates tools", () => {
+  const mockTemplate = { id: 1, name: "Temp", uuid: "u", category: "cat", subject: "sub" };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should list templates", async () => {
+    (apiClient.get as jest.Mock).mockResolvedValue({ data: [mockTemplate] });
+
+    const result = await listEmailTemplates({ accountId: 2 });
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      "/api/accounts/2/email_templates"
+    );
+    expect(result).toEqual({
+      content: [{ type: "text", text: JSON.stringify([mockTemplate]) }],
+    });
+  });
+
+  it("should create template", async () => {
+    (apiClient.post as jest.Mock).mockResolvedValue({ data: mockTemplate });
+
+    const result = await createEmailTemplate({
+      accountId: 2,
+      name: "Temp",
+      subject: "sub",
+      category: "cat",
+    });
+
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/api/accounts/2/email_templates",
+      {
+        name: "Temp",
+        subject: "sub",
+        category: "cat",
+        body_text: undefined,
+        body_html: undefined,
+      }
+    );
+    expect(result).toEqual({
+      content: [{ type: "text", text: JSON.stringify(mockTemplate) }],
+    });
+  });
+
+  it("should update template", async () => {
+    (apiClient.patch as jest.Mock).mockResolvedValue({ data: mockTemplate });
+
+    const result = await updateEmailTemplate({
+      accountId: 2,
+      emailTemplateId: 3,
+      name: "Temp",
+    });
+
+    expect(apiClient.patch).toHaveBeenCalledWith(
+      "/api/accounts/2/email_templates/3",
+      {
+        name: "Temp",
+        subject: undefined,
+        category: undefined,
+        body_text: undefined,
+        body_html: undefined,
+      }
+    );
+    expect(result).toEqual({
+      content: [{ type: "text", text: JSON.stringify(mockTemplate) }],
+    });
+  });
+
+  it("should delete template", async () => {
+    (apiClient.delete as jest.Mock).mockResolvedValue({});
+
+    const result = await deleteEmailTemplate({
+      accountId: 2,
+      emailTemplateId: 3,
+    });
+
+    expect(apiClient.delete).toHaveBeenCalledWith(
+      "/api/accounts/2/email_templates/3"
+    );
+    expect(result).toEqual({
+      content: [{ type: "text", text: "Template deleted successfully" }],
+    });
+  });
+
+  it("should handle errors", async () => {
+    (apiClient.get as jest.Mock).mockRejectedValue(new Error("fail"));
+
+    const result = await listEmailTemplates({ accountId: 2 });
+
+    expect(result).toEqual({
+      content: [{ type: "text", text: "Failed to fetch templates: fail" }],
+      isError: true,
+    });
+  });
+});

--- a/src/tools/templates/index.ts
+++ b/src/tools/templates/index.ts
@@ -1,0 +1,13 @@
+export {
+  listEmailTemplatesSchema,
+  createEmailTemplateSchema,
+  updateEmailTemplateSchema,
+  deleteEmailTemplateSchema,
+} from "./schema";
+
+export {
+  listEmailTemplates,
+  createEmailTemplate,
+  updateEmailTemplate,
+  deleteEmailTemplate,
+} from "./templates";

--- a/src/tools/templates/schema.ts
+++ b/src/tools/templates/schema.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+const accountId = z.number().describe("Unique account ID");
+const templateId = z.number().describe("Unique email template ID");
+
+export const listEmailTemplatesSchema = {
+  accountId,
+};
+
+export const createEmailTemplateSchema = {
+  accountId,
+  name: z.string().describe("Template name"),
+  subject: z.string().describe("Template subject"),
+  category: z.string().describe("Template category"),
+  body_text: z.string().optional().describe("Text body"),
+  body_html: z.string().optional().describe("HTML body"),
+};
+
+export const updateEmailTemplateSchema = {
+  accountId,
+  emailTemplateId: templateId,
+  name: z.string().optional().describe("Template name"),
+  subject: z.string().optional().describe("Template subject"),
+  category: z.string().optional().describe("Template category"),
+  body_text: z.string().optional().describe("Text body"),
+  body_html: z.string().optional().describe("HTML body"),
+};
+
+export const deleteEmailTemplateSchema = {
+  accountId,
+  emailTemplateId: templateId,
+};

--- a/src/tools/templates/templates.ts
+++ b/src/tools/templates/templates.ts
@@ -1,0 +1,85 @@
+import apiClient from "../../apiClient";
+import {
+  ListEmailTemplatesRequest,
+  CreateEmailTemplateRequest,
+  UpdateEmailTemplateRequest,
+  DeleteEmailTemplateRequest,
+} from "../../types/templates";
+
+export async function listEmailTemplates({ accountId }: ListEmailTemplatesRequest): Promise<{ content: any[]; isError?: boolean }> {
+  try {
+    const response = await apiClient.get(`/api/accounts/${accountId}/email_templates`);
+    return {
+      content: [{ type: "text", text: JSON.stringify(response.data) }],
+    };
+  } catch (error) {
+    console.error("Error fetching templates:", error);
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Failed to fetch templates: ${message}` }],
+      isError: true,
+    };
+  }
+}
+
+export async function createEmailTemplate({ accountId, name, subject, category, body_text, body_html, }: CreateEmailTemplateRequest): Promise<{ content: any[]; isError?: boolean }> {
+  try {
+    const response = await apiClient.post(`/api/accounts/${accountId}/email_templates`, {
+      name,
+      subject,
+      category,
+      body_text,
+      body_html,
+    });
+
+    return {
+      content: [{ type: "text", text: JSON.stringify(response.data) }],
+    };
+  } catch (error) {
+    console.error("Error creating template:", error);
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Failed to create template: ${message}` }],
+      isError: true,
+    };
+  }
+}
+
+export async function updateEmailTemplate({ accountId, emailTemplateId, name, subject, category, body_text, body_html, }: UpdateEmailTemplateRequest): Promise<{ content: any[]; isError?: boolean }> {
+  try {
+    const response = await apiClient.patch(`/api/accounts/${accountId}/email_templates/${emailTemplateId}`, {
+      name,
+      subject,
+      category,
+      body_text,
+      body_html,
+    });
+
+    return {
+      content: [{ type: "text", text: JSON.stringify(response.data) }],
+    };
+  } catch (error) {
+    console.error("Error updating template:", error);
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Failed to update template: ${message}` }],
+      isError: true,
+    };
+  }
+}
+
+export async function deleteEmailTemplate({ accountId, emailTemplateId }: DeleteEmailTemplateRequest): Promise<{ content: any[]; isError?: boolean }> {
+  try {
+    await apiClient.delete(`/api/accounts/${accountId}/email_templates/${emailTemplateId}`);
+    return {
+      content: [{ type: "text", text: "Template deleted successfully" }],
+    };
+  } catch (error) {
+    console.error("Error deleting template:", error);
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Failed to delete template: ${message}` }],
+      isError: true,
+    };
+  }
+}

--- a/src/types/templates.ts
+++ b/src/types/templates.ts
@@ -1,0 +1,39 @@
+export interface EmailTemplate {
+  id: number;
+  name: string;
+  uuid: string;
+  category: string;
+  subject: string;
+  body_text?: string;
+  body_html?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ListEmailTemplatesRequest {
+  accountId: number;
+}
+
+export interface CreateEmailTemplateRequest {
+  accountId: number;
+  name: string;
+  subject: string;
+  category: string;
+  body_text?: string;
+  body_html?: string;
+}
+
+export interface UpdateEmailTemplateRequest {
+  accountId: number;
+  emailTemplateId: number;
+  name?: string;
+  subject?: string;
+  category?: string;
+  body_text?: string;
+  body_html?: string;
+}
+
+export interface DeleteEmailTemplateRequest {
+  accountId: number;
+  emailTemplateId: number;
+}


### PR DESCRIPTION
## Summary
- support Mailtrap API for templates
- expose MCP tools for listing, creating, updating and deleting templates
- document new tools
- test template tool functions

## Testing
- `npm test`
- `npx tsc -p . --noEmit`