### PR TITLE
Add email template management support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Add the following configuration:
       "args": ["-y", "mcp-mailtrap"],
       "env": {
         "MAILTRAP_API_TOKEN": "your_mailtrap_api_token",
+        "MAILTRAP_ACCOUNT_ID": "your_account_id",
         "DEFAULT_FROM_EMAIL": "your_sender@example.com"
       }
     }
@@ -41,6 +42,7 @@ If you are using `asdf` for managing Node.js you must use absolute path to execu
         "ASDF_DATA_DIR": "/Users/<username>/.asdf",
         "ASDF_NODEJS_VERSION": "20.6.1",
         "MAILTRAP_API_TOKEN": "your_mailtrap_api_token",
+        "MAILTRAP_ACCOUNT_ID": "your_account_id",
         "DEFAULT_FROM_EMAIL": "your_sender@example.com"
       }
     }
@@ -83,6 +85,7 @@ Then, in the settings file, add the following configuration:
         "args": ["-y", "mcp-mailtrap"],
         "env": {
           "MAILTRAP_API_TOKEN": "your_mailtrap_api_token",
+          "MAILTRAP_ACCOUNT_ID": "your_account_id",
           "DEFAULT_FROM_EMAIL": "your_sender@example.com"
         }
       }
@@ -148,6 +151,7 @@ Add the following configuration:
       "args": ["/path/to/mailtrap-mcp/dist/index.js"],
       "env": {
         "MAILTRAP_API_TOKEN": "your_mailtrap_api_token",
+        "MAILTRAP_ACCOUNT_ID": "your_account_id",
         "DEFAULT_FROM_EMAIL": "your_sender@example.com"
       }
     }
@@ -171,6 +175,7 @@ If you are using `asdf` for managing Node.js you should use absolute path to exe
         "ASDF_DATA_DIR": "/Users/<username>/.asdf",
         "ASDF_NODEJS_VERSION": "20.6.1",
         "MAILTRAP_API_TOKEN": "your_mailtrap_api_token",
+        "MAILTRAP_ACCOUNT_ID": "your_account_id",
         "DEFAULT_FROM_EMAIL": "your_sender@example.com"
       }
     }
@@ -192,6 +197,7 @@ If you are using `asdf` for managing Node.js you should use absolute path to exe
         "args": ["/path/to/mailtrap-mcp/dist/index.js"],
         "env": {
           "MAILTRAP_API_TOKEN": "your_mailtrap_api_token",
+          "MAILTRAP_ACCOUNT_ID": "your_account_id",
           "DEFAULT_FROM_EMAIL": "your_sender@example.com"
         }
       }

--- a/jest/setEnvVars.js
+++ b/jest/setEnvVars.js
@@ -1,1 +1,3 @@
 process.env.DEFAULT_FROM_EMAIL = "default@example.com";
+process.env.MAILTRAP_API_TOKEN = "test-token";
+process.env.MAILTRAP_ACCOUNT_ID = "123";

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,15 @@ import dotenv from "dotenv";
 import CONFIG from "./config";
 
 import { sendEmailSchema, sendEmail } from "./tools/sendEmail";
+import {
+  createTemplateSchema,
+  updateTemplateSchema,
+  deleteTemplateSchema,
+  getTemplates,
+  createTemplate,
+  updateTemplate,
+  deleteTemplate,
+} from "./tools/templates";
 
 dotenv.config();
 
@@ -19,6 +28,42 @@ server.tool(
   "Send transactional email using Mailtrap",
   sendEmailSchema,
   sendEmail
+);
+
+server.tool("get-email-templates", "Get all email templates", {}, async () => {
+  const templates = await getTemplates();
+  return { content: [{ type: "text", text: JSON.stringify(templates, null, 2) }] };
+});
+
+server.tool(
+  "create-email-template",
+  "Create a new email template",
+  createTemplateSchema,
+  async (args) => {
+    const template = await createTemplate(args as any);
+    return { content: [{ type: "text", text: JSON.stringify(template, null, 2) }] };
+  }
+);
+
+server.tool(
+  "update-email-template",
+  "Update an email template",
+  updateTemplateSchema,
+  async (args) => {
+    const { id, ...rest } = args as any;
+    const template = await updateTemplate(id, rest as any);
+    return { content: [{ type: "text", text: JSON.stringify(template, null, 2) }] };
+  }
+);
+
+server.tool(
+  "delete-email-template",
+  "Delete an email template",
+  deleteTemplateSchema,
+  async ({ id }: any) => {
+    await deleteTemplate(id);
+    return { content: [{ type: "text", text: "Deleted" }] };
+  }
 );
 
 async function main() {

--- a/src/tools/templates/__tests__/templates.test.ts
+++ b/src/tools/templates/__tests__/templates.test.ts
@@ -1,0 +1,43 @@
+import axios from "axios";
+
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const apiInstance = { get: jest.fn(), post: jest.fn(), patch: jest.fn(), delete: jest.fn() };
+(mockedAxios.create as jest.Mock).mockReturnValue(apiInstance);
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const templates = require("../templates");
+const { getTemplates, createTemplate, updateTemplate, deleteTemplate } = templates;
+
+describe("templates tools", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should get templates", async () => {
+    apiInstance.get.mockResolvedValue({ data: [{ id: 1 }] });
+    const res = await getTemplates();
+    expect(apiInstance.get).toHaveBeenCalledWith("/email_templates");
+    expect(res).toEqual([{ id: 1 }]);
+  });
+
+  it("should create template", async () => {
+    apiInstance.post.mockResolvedValue({ data: { id: 2 } });
+    const res = await createTemplate({ name: "t", subject: "s" });
+    expect(apiInstance.post).toHaveBeenCalledWith("/email_templates", { name: "t", subject: "s" });
+    expect(res).toEqual({ id: 2 });
+  });
+
+  it("should update template", async () => {
+    apiInstance.patch.mockResolvedValue({ data: { id: 3 } });
+    const res = await updateTemplate(3, { name: "n" });
+    expect(apiInstance.patch).toHaveBeenCalledWith("/email_templates/3", { name: "n" });
+    expect(res).toEqual({ id: 3 });
+  });
+
+  it("should delete template", async () => {
+    apiInstance.delete.mockResolvedValue({});
+    await deleteTemplate(4);
+    expect(apiInstance.delete).toHaveBeenCalledWith("/email_templates/4");
+  });
+});

--- a/src/tools/templates/index.ts
+++ b/src/tools/templates/index.ts
@@ -1,0 +1,4 @@
+import { createTemplateSchema, updateTemplateSchema, deleteTemplateSchema } from "./schemas";
+import { getTemplates, createTemplate, updateTemplate, deleteTemplate } from "./templates";
+
+export { createTemplateSchema, updateTemplateSchema, deleteTemplateSchema, getTemplates, createTemplate, updateTemplate, deleteTemplate };

--- a/src/tools/templates/schemas.ts
+++ b/src/tools/templates/schemas.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const createTemplateSchema = {
+  name: z.string().describe("Template name"),
+  subject: z.string().describe("Email subject"),
+  category: z.string().optional().describe("Template category"),
+  text: z.string().optional().describe("Text body"),
+  html: z.string().optional().describe("HTML body"),
+};
+
+export const updateTemplateSchema = {
+  id: z.number().describe("Template ID"),
+  name: z.string().optional().describe("Template name"),
+  subject: z.string().optional().describe("Email subject"),
+  category: z.string().optional().describe("Template category"),
+  text: z.string().optional().describe("Text body"),
+  html: z.string().optional().describe("HTML body"),
+};
+
+export const deleteTemplateSchema = {
+  id: z.number().describe("Template ID"),
+};
+

--- a/src/tools/templates/templates.ts
+++ b/src/tools/templates/templates.ts
@@ -1,0 +1,65 @@
+import axios from "axios";
+
+const { MAILTRAP_API_TOKEN, MAILTRAP_ACCOUNT_ID } = process.env;
+
+if (!MAILTRAP_API_TOKEN) {
+  console.error("Error: MAILTRAP_API_TOKEN environment variable is required");
+  process.exit(1);
+}
+if (!MAILTRAP_ACCOUNT_ID) {
+  console.error("Error: MAILTRAP_ACCOUNT_ID environment variable is required");
+  process.exit(1);
+}
+
+const api = axios.create({
+  baseURL: `https://mailtrap.io/api/accounts/${MAILTRAP_ACCOUNT_ID}`,
+  headers: {
+    "Api-Token": MAILTRAP_API_TOKEN,
+    "Content-Type": "application/json",
+  },
+});
+
+export async function getTemplates() {
+  const { data } = await api.get("/email_templates");
+  return data;
+}
+
+export async function createTemplate(template: {
+  name: string;
+  subject: string;
+  category?: string;
+  text?: string;
+  html?: string;
+}) {
+  const body: any = {
+    name: template.name,
+    subject: template.subject,
+  };
+  if (template.category) body.category = template.category;
+  if (template.text) body.body_text = template.text;
+  if (template.html) body.body_html = template.html;
+  const { data } = await api.post("/email_templates", body);
+  return data;
+}
+
+export async function updateTemplate(id: number, template: {
+  name?: string;
+  subject?: string;
+  category?: string;
+  text?: string;
+  html?: string;
+}) {
+  const body: any = {};
+  if (template.name) body.name = template.name;
+  if (template.subject) body.subject = template.subject;
+  if (template.category) body.category = template.category;
+  if (template.text) body.body_text = template.text;
+  if (template.html) body.body_html = template.html;
+  const { data } = await api.patch(`/email_templates/${id}`, body);
+  return data;
+}
+
+export async function deleteTemplate(id: number) {
+  await api.delete(`/email_templates/${id}`);
+}
+


### PR DESCRIPTION
## Summary
- add tools for Mailtrap email template management
- document MAILTRAP_ACCOUNT_ID env var
- include env vars in tests

## Testing
- `npm test`
- `npm run build`
