### PR TITLE
Enable Docker usage for MCP

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+dist
+.git
+.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Use multi-stage build to keep final image small
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm ci
+
+# Copy source and build
+COPY . .
+RUN npm run build && chmod +x dist/index.js
+
+# Final image
+FROM node:22-alpine
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Copy built application
+COPY --from=builder /app/dist ./dist
+
+ENTRYPOINT ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -94,8 +94,71 @@ Then, in the settings file, add the following configuration:
 }
 ```
 
+
 > [!TIP]
 > Don't forget to restart your MCP server after changing the "env" section.
+
+### Docker
+
+You can run the Mailtrap MCP inside a Docker container. First build the image:
+
+```bash
+docker build -t mailtrap-mcp .
+```
+
+Then start the container, providing the required environment variables:
+
+```bash
+docker run \
+  -e MAILTRAP_API_TOKEN=your_mailtrap_api_token \
+  -e MAILTRAP_ACCOUNT_ID=your_account_id \
+  -e DEFAULT_FROM_EMAIL=your_sender@example.com \
+  mailtrap-mcp
+```
+
+#### Using with Claude Desktop or Cursor
+
+Add the following configuration:
+
+```json
+{
+  "mcpServers": {
+    "mailtrap": {
+      "command": "docker",
+      "args": [
+        "run", "--rm",
+        "-e", "MAILTRAP_API_TOKEN=${MAILTRAP_API_TOKEN}",
+        "-e", "MAILTRAP_ACCOUNT_ID=${MAILTRAP_ACCOUNT_ID}",
+        "-e", "DEFAULT_FROM_EMAIL=${DEFAULT_FROM_EMAIL}",
+        "mailtrap-mcp"
+      ]
+    }
+  }
+}
+```
+
+#### Using with VS Code
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "mailtrap": {
+        "command": "docker",
+        "args": [
+          "run", "--rm",
+          "-e", "MAILTRAP_API_TOKEN=${MAILTRAP_API_TOKEN}",
+          "-e", "MAILTRAP_ACCOUNT_ID=${MAILTRAP_ACCOUNT_ID}",
+          "-e", "DEFAULT_FROM_EMAIL=${DEFAULT_FROM_EMAIL}",
+          "mailtrap-mcp"
+        ]
+      }
+    }
+  }
+}
+```
+
+
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",
+        "axios": "^1.8.4",
         "dotenv": "^16.4.7",
         "mailtrap": "^4.0.0",
         "zod": "^3.24.2"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.8.0",
+    "axios": "^1.8.4",
     "dotenv": "^16.4.7",
     "mailtrap": "^4.0.0",
     "zod": "^3.24.2"


### PR DESCRIPTION
## Summary
- add Dockerfile and .dockerignore to build container image
- document Docker usage in README
- add `axios` dependency
- provide configuration examples for Claude/Cursor and VS Code when running via Docker

## Testing
- `npm run lint`
- `npm test`
