### PR TITLE
Add email template management support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Add the following configuration:
       "args": ["-y", "mcp-mailtrap"],
       "env": {
         "MAILTRAP_API_TOKEN": "your_mailtrap_api_token",
+        "MAILTRAP_ACCOUNT_ID": "your_account_id",
         "DEFAULT_FROM_EMAIL": "your_sender@example.com"
       }
     }
@@ -41,6 +42,7 @@ If you are using `asdf` for managing Node.js you must use absolute path to execu
         "ASDF_DATA_DIR": "/Users/<username>/.asdf",
         "ASDF_NODEJS_VERSION": "20.6.1",
         "MAILTRAP_API_TOKEN": "your_mailtrap_api_token",
+        "MAILTRAP_ACCOUNT_ID": "your_account_id",
         "DEFAULT_FROM_EMAIL": "your_sender@example.com"
       }
     }
@@ -83,6 +85,7 @@ Then, in the settings file, add the following configuration:
         "args": ["-y", "mcp-mailtrap"],
         "env": {
           "MAILTRAP_API_TOKEN": "your_mailtrap_api_token",
+          "MAILTRAP_ACCOUNT_ID": "your_account_id",
           "DEFAULT_FROM_EMAIL": "your_sender@example.com"
         }
       }
@@ -148,6 +151,7 @@ Add the following configuration:
       "args": ["/path/to/mailtrap-mcp/dist/index.js"],
       "env": {
         "MAILTRAP_API_TOKEN": "your_mailtrap_api_token",
+        "MAILTRAP_ACCOUNT_ID": "your_account_id",
         "DEFAULT_FROM_EMAIL": "your_sender@example.com"
       }
     }
@@ -171,6 +175,7 @@ If you are using `asdf` for managing Node.js you should use absolute path to exe
         "ASDF_DATA_DIR": "/Users/<username>/.asdf",
         "ASDF_NODEJS_VERSION": "20.6.1",
         "MAILTRAP_API_TOKEN": "your_mailtrap_api_token",
+        "MAILTRAP_ACCOUNT_ID": "your_account_id",
         "DEFAULT_FROM_EMAIL": "your_sender@example.com"
       }
     }
@@ -192,6 +197,7 @@ If you are using `asdf` for managing Node.js you should use absolute path to exe
         "args": ["/path/to/mailtrap-mcp/dist/index.js"],
         "env": {
           "MAILTRAP_API_TOKEN": "your_mailtrap_api_token",
+          "MAILTRAP_ACCOUNT_ID": "your_account_id",
           "DEFAULT_FROM_EMAIL": "your_sender@example.com"
         }
       }

--- a/jest/setEnvVars.js
+++ b/jest/setEnvVars.js
@@ -1,1 +1,3 @@
 process.env.DEFAULT_FROM_EMAIL = "default@example.com";
+process.env.MAILTRAP_API_TOKEN = "test-token";
+process.env.MAILTRAP_ACCOUNT_ID = "123";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-mailtrap",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-mailtrap",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,15 @@ import dotenv from "dotenv";
 import CONFIG from "./config";
 
 import { sendEmailSchema, sendEmail } from "./tools/sendEmail";
+import {
+  createTemplateSchema,
+  updateTemplateSchema,
+  deleteTemplateSchema,
+  getTemplates,
+  createTemplate,
+  updateTemplate,
+  deleteTemplate,
+} from "./tools/templates";
 
 dotenv.config();
 
@@ -14,16 +23,51 @@ const server = new McpServer({
   version: CONFIG.MCP_SERVER_VERSION,
 });
 
-server.tool(
-  "send-email",
-  "Send transactional email using Mailtrap",
-  sendEmailSchema,
-  sendEmail
-);
+server.tool("send-email", "Send transactional email using Mailtrap", sendEmailSchema, sendEmail);
+
+server.tool("get-email-templates", "Get all email templates", {}, async () => {
+  try {
+    const templates = await getTemplates();
+    return { content: [{ type: "text", text: JSON.stringify(templates, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+server.tool("create-email-template", "Create a new email template", createTemplateSchema, async (args) => {
+  try {
+    const template = await createTemplate(args as any);
+    return { content: [{ type: "text", text: JSON.stringify(template, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+server.tool("update-email-template", "Update an email template", updateTemplateSchema, async (args) => {
+  try {
+    const { id, ...rest } = args as any;
+    const template = await updateTemplate(id, rest as any);
+    return { content: [{ type: "text", text: JSON.stringify(template, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+server.tool("delete-email-template", "Delete an email template", deleteTemplateSchema, async ({ id }: any) => {
+  try {
+    await deleteTemplate(id);
+    return { content: [{ type: "text", text: "Deleted" }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
 
 async function main() {
   const transport = new StdioServerTransport();
-
   await server.connect(transport);
 }
 
@@ -31,3 +75,4 @@ main().catch((error) => {
   console.error("Fatal error:", error);
   process.exit(1);
 });
+

--- a/src/tools/templates/__tests__/templates.test.ts
+++ b/src/tools/templates/__tests__/templates.test.ts
@@ -1,0 +1,42 @@
+import axios from "axios";
+
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const apiInstance = { get: jest.fn(), post: jest.fn(), patch: jest.fn(), delete: jest.fn() } as const;
+(mockedAxios.create as jest.Mock).mockReturnValue(apiInstance);
+
+import { getTemplates, createTemplate, updateTemplate, deleteTemplate } from "../templates";
+
+describe("templates tools", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should get templates", async () => {
+    apiInstance.get.mockResolvedValue({ data: [{ id: 1 }] });
+    const res = await getTemplates();
+    expect(apiInstance.get).toHaveBeenCalledWith("/email_templates");
+    expect(res).toEqual([{ id: 1 }]);
+  });
+
+  it("should create template", async () => {
+    apiInstance.post.mockResolvedValue({ data: { id: 2 } });
+    const res = await createTemplate({ name: "Template", subject: "Subject" });
+    expect(apiInstance.post).toHaveBeenCalledWith("/email_templates", { name: "Template", subject: "Subject" });
+    expect(res).toEqual({ id: 2 });
+  });
+
+  it("should update template", async () => {
+    apiInstance.patch.mockResolvedValue({ data: { id: 3 } });
+    const res = await updateTemplate(3, { name: "Updated" });
+    expect(apiInstance.patch).toHaveBeenCalledWith("/email_templates/3", { name: "Updated" });
+    expect(res).toEqual({ id: 3 });
+  });
+
+  it("should delete template", async () => {
+    apiInstance.delete.mockResolvedValue({});
+    await deleteTemplate(4);
+    expect(apiInstance.delete).toHaveBeenCalledWith("/email_templates/4");
+  });
+});
+

--- a/src/tools/templates/index.ts
+++ b/src/tools/templates/index.ts
@@ -1,0 +1,4 @@
+import { createTemplateSchema, updateTemplateSchema, deleteTemplateSchema } from "./schemas";
+import { getTemplates, createTemplate, updateTemplate, deleteTemplate } from "./templates";
+
+export { createTemplateSchema, updateTemplateSchema, deleteTemplateSchema, getTemplates, createTemplate, updateTemplate, deleteTemplate };

--- a/src/tools/templates/schemas.ts
+++ b/src/tools/templates/schemas.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const createTemplateSchema = {
+  name: z.string().describe("Template name"),
+  subject: z.string().describe("Email subject"),
+  category: z.string().optional().describe("Template category"),
+  text: z.string().optional().describe("Text body"),
+  html: z.string().optional().describe("HTML body"),
+};
+
+export const updateTemplateSchema = {
+  id: z.number().describe("Template ID"),
+  name: z.string().optional().describe("Template name"),
+  subject: z.string().optional().describe("Email subject"),
+  category: z.string().optional().describe("Template category"),
+  text: z.string().optional().describe("Text body"),
+  html: z.string().optional().describe("HTML body"),
+};
+
+export const deleteTemplateSchema = {
+  id: z.number().describe("Template ID"),
+};
+

--- a/src/tools/templates/templates.ts
+++ b/src/tools/templates/templates.ts
@@ -1,0 +1,97 @@
+import axios, { AxiosError, AxiosInstance } from "axios";
+
+const { MAILTRAP_API_TOKEN, MAILTRAP_ACCOUNT_ID } = process.env;
+
+if (!MAILTRAP_API_TOKEN) {
+  console.error("Error: MAILTRAP_API_TOKEN environment variable is required");
+  process.exit(1);
+}
+if (!MAILTRAP_ACCOUNT_ID) {
+  console.error("Error: MAILTRAP_ACCOUNT_ID environment variable is required");
+  process.exit(1);
+}
+
+const api: AxiosInstance = axios.create({
+  baseURL: `https://mailtrap.io/api/accounts/${MAILTRAP_ACCOUNT_ID}`,
+  headers: {
+    "Api-Token": MAILTRAP_API_TOKEN,
+    "Content-Type": "application/json",
+  },
+});
+
+export interface EmailTemplate {
+  id: number;
+  name: string;
+  subject: string;
+  category?: string | null;
+  body_text?: string | null;
+  body_html?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface CreateTemplateRequest {
+  name: string;
+  subject: string;
+  category?: string;
+  text?: string;
+  html?: string;
+}
+
+export interface UpdateTemplateRequest {
+  name?: string;
+  subject?: string;
+  category?: string;
+  text?: string;
+  html?: string;
+}
+
+export async function getTemplates(): Promise<EmailTemplate[]> {
+  try {
+    const { data } = await api.get<EmailTemplate[]>("/email_templates");
+    return data;
+  } catch (err) {
+    const message = (err as AxiosError).message;
+    throw new Error(`Failed to list templates: ${message}`);
+  }
+}
+
+export async function createTemplate(req: CreateTemplateRequest): Promise<EmailTemplate> {
+  try {
+    const body: Record<string, unknown> = { name: req.name, subject: req.subject };
+    if (req.category) body.category = req.category;
+    if (req.text) body.body_text = req.text;
+    if (req.html) body.body_html = req.html;
+    const { data } = await api.post<EmailTemplate>("/email_templates", body);
+    return data;
+  } catch (err) {
+    const message = (err as AxiosError).message;
+    throw new Error(`Failed to create template: ${message}`);
+  }
+}
+
+export async function updateTemplate(id: number, req: UpdateTemplateRequest): Promise<EmailTemplate> {
+  try {
+    const body: Record<string, unknown> = {};
+    if (req.name) body.name = req.name;
+    if (req.subject) body.subject = req.subject;
+    if (req.category) body.category = req.category;
+    if (req.text) body.body_text = req.text;
+    if (req.html) body.body_html = req.html;
+    const { data } = await api.patch<EmailTemplate>(`/email_templates/${id}`, body);
+    return data;
+  } catch (err) {
+    const message = (err as AxiosError).message;
+    throw new Error(`Failed to update template: ${message}`);
+  }
+}
+
+export async function deleteTemplate(id: number): Promise<void> {
+  try {
+    await api.delete(`/email_templates/${id}`);
+  } catch (err) {
+    const message = (err as AxiosError).message;
+    throw new Error(`Failed to delete template: ${message}`);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add tools for Mailtrap email template management
- document MAILTRAP_ACCOUNT_ID env var
- include env vars in tests
- improve error handling and typings

## Testing
- `npm test`
- `npm run build`
