### PR TITLE
Remove axios references and use fetch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,48 +23,74 @@ const server = new McpServer({
   version: CONFIG.MCP_SERVER_VERSION,
 });
 
-server.tool("send-email", "Send transactional email using Mailtrap", sendEmailSchema, sendEmail);
+server.tool(
+  "send-email",
+  "Send transactional email using Mailtrap",
+  sendEmailSchema,
+  sendEmail
+);
 
 server.tool("get-email-templates", "Get all email templates", {}, async () => {
   try {
     const templates = await getTemplates();
-    return { content: [{ type: "text", text: JSON.stringify(templates, null, 2) }] };
+    return {
+      content: [{ type: "text", text: JSON.stringify(templates, null, 2) }],
+    };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return { content: [{ type: "text", text: message }], isError: true };
   }
 });
 
-server.tool("create-email-template", "Create a new email template", createTemplateSchema, async (args) => {
-  try {
-    const template = await createTemplate(args as any);
-    return { content: [{ type: "text", text: JSON.stringify(template, null, 2) }] };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return { content: [{ type: "text", text: message }], isError: true };
+server.tool(
+  "create-email-template",
+  "Create a new email template",
+  createTemplateSchema,
+  async (args) => {
+    try {
+      const template = await createTemplate(args as any);
+      return {
+        content: [{ type: "text", text: JSON.stringify(template, null, 2) }],
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { content: [{ type: "text", text: message }], isError: true };
+    }
   }
-});
+);
 
-server.tool("update-email-template", "Update an email template", updateTemplateSchema, async (args) => {
-  try {
-    const { id, ...rest } = args as any;
-    const template = await updateTemplate(id, rest as any);
-    return { content: [{ type: "text", text: JSON.stringify(template, null, 2) }] };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return { content: [{ type: "text", text: message }], isError: true };
+server.tool(
+  "update-email-template",
+  "Update an email template",
+  updateTemplateSchema,
+  async (args) => {
+    try {
+      const { id, ...rest } = args as any;
+      const template = await updateTemplate(id, rest as any);
+      return {
+        content: [{ type: "text", text: JSON.stringify(template, null, 2) }],
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { content: [{ type: "text", text: message }], isError: true };
+    }
   }
-});
+);
 
-server.tool("delete-email-template", "Delete an email template", deleteTemplateSchema, async ({ id }: any) => {
-  try {
-    await deleteTemplate(id);
-    return { content: [{ type: "text", text: "Deleted" }] };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return { content: [{ type: "text", text: message }], isError: true };
+server.tool(
+  "delete-email-template",
+  "Delete an email template",
+  deleteTemplateSchema,
+  async ({ id }: any) => {
+    try {
+      await deleteTemplate(id);
+      return { content: [{ type: "text", text: "Deleted" }] };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { content: [{ type: "text", text: message }], isError: true };
+    }
   }
-});
+);
 
 async function main() {
   const transport = new StdioServerTransport();
@@ -75,4 +101,3 @@ main().catch((error) => {
   console.error("Fatal error:", error);
   process.exit(1);
 });
-

--- a/src/tools/templates/__tests__/templates.test.ts
+++ b/src/tools/templates/__tests__/templates.test.ts
@@ -1,42 +1,71 @@
-import axios from "axios";
-
-jest.mock("axios");
-const mockedAxios = axios as jest.Mocked<typeof axios>;
-const apiInstance = { get: jest.fn(), post: jest.fn(), patch: jest.fn(), delete: jest.fn() } as const;
-(mockedAxios.create as jest.Mock).mockReturnValue(apiInstance);
-
-import { getTemplates, createTemplate, updateTemplate, deleteTemplate } from "../templates";
+import {
+  getTemplates,
+  createTemplate,
+  updateTemplate,
+  deleteTemplate,
+} from "../templates";
 
 describe("templates tools", () => {
+  const fetchMock = jest.fn();
+
   beforeEach(() => {
-    jest.clearAllMocks();
+    fetchMock.mockReset();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).fetch = fetchMock;
   });
 
   it("should get templates", async () => {
-    apiInstance.get.mockResolvedValue({ data: [{ id: 1 }] });
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [{ id: 1 }],
+    });
     const res = await getTemplates();
-    expect(apiInstance.get).toHaveBeenCalledWith("/email_templates");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://mailtrap.io/api/accounts/123/email_templates",
+      expect.objectContaining({ method: "GET" })
+    );
     expect(res).toEqual([{ id: 1 }]);
   });
 
   it("should create template", async () => {
-    apiInstance.post.mockResolvedValue({ data: { id: 2 } });
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: 2 }),
+    });
     const res = await createTemplate({ name: "Template", subject: "Subject" });
-    expect(apiInstance.post).toHaveBeenCalledWith("/email_templates", { name: "Template", subject: "Subject" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://mailtrap.io/api/accounts/123/email_templates",
+      expect.objectContaining({ method: "POST" })
+    );
     expect(res).toEqual({ id: 2 });
   });
 
   it("should update template", async () => {
-    apiInstance.patch.mockResolvedValue({ data: { id: 3 } });
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: 3 }),
+    });
     const res = await updateTemplate(3, { name: "Updated" });
-    expect(apiInstance.patch).toHaveBeenCalledWith("/email_templates/3", { name: "Updated" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://mailtrap.io/api/accounts/123/email_templates/3",
+      expect.objectContaining({ method: "PATCH" })
+    );
     expect(res).toEqual({ id: 3 });
   });
 
   it("should delete template", async () => {
-    apiInstance.delete.mockResolvedValue({});
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 204,
+      text: async () => "",
+    });
     await deleteTemplate(4);
-    expect(apiInstance.delete).toHaveBeenCalledWith("/email_templates/4");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://mailtrap.io/api/accounts/123/email_templates/4",
+      expect.objectContaining({ method: "DELETE" })
+    );
   });
 });
-

--- a/src/tools/templates/index.ts
+++ b/src/tools/templates/index.ts
@@ -1,4 +1,21 @@
-import { createTemplateSchema, updateTemplateSchema, deleteTemplateSchema } from "./schemas";
-import { getTemplates, createTemplate, updateTemplate, deleteTemplate } from "./templates";
+import {
+  createTemplateSchema,
+  updateTemplateSchema,
+  deleteTemplateSchema,
+} from "./schemas";
+import {
+  getTemplates,
+  createTemplate,
+  updateTemplate,
+  deleteTemplate,
+} from "./templates";
 
-export { createTemplateSchema, updateTemplateSchema, deleteTemplateSchema, getTemplates, createTemplate, updateTemplate, deleteTemplate };
+export {
+  createTemplateSchema,
+  updateTemplateSchema,
+  deleteTemplateSchema,
+  getTemplates,
+  createTemplate,
+  updateTemplate,
+  deleteTemplate,
+};

--- a/src/tools/templates/schemas.ts
+++ b/src/tools/templates/schemas.ts
@@ -20,4 +20,3 @@ export const updateTemplateSchema = {
 export const deleteTemplateSchema = {
   id: z.number().describe("Template ID"),
 };
-


### PR DESCRIPTION
## Summary
- eliminate axios usage in templates
- adjust template tests for fetch
- format code with eslint autofix

## Testing
- `npm run lint:eslint`
- `npm run lint:tsc`
- `npm test`
- `npm run build`
