### PR TITLE
Add email-logs tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
-* Add **get-sending-stats** tool: check delivery, bounce, open, click, and spam rates for a date range; optional breakdown by domain, category, email service provider, or date. Requires `MAILTRAP_ACCOUNT_ID`.
+* Add **list-email-logs** and **get-email-log-message** tools: query sent-mail delivery history with filters and pagination; inspect a single log by UUID (summary, event timeline, optional body via `include_content`).
+* Add **get-sending-stats** tool: check delivery, bounce, open, click, and spam rates for a date range; optional breakdown by domain, category, email service provider, or date.
 
 ## [0.1.0] - 2025-12-09
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,16 +5,19 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Development Commands
 
 ### Build and Development
+
 - `npm run build` - Compile TypeScript to JavaScript in the `dist/` directory
 - `npm run dev` - Run the MCP server with the MCP Inspector for testing
 - `npm run prepublish` - Build the project and make the executable script executable
 
 ### Code Quality
+
 - `npm run lint` - Run both ESLint and TypeScript checks
 - `npm run lint:eslint` - Run ESLint for code style checking
 - `npm run lint:tsc` - Run TypeScript compiler for type checking
 
 ### Testing
+
 - `npm test` - Run all Jest tests
 - `npm run test:watch` - Run tests in watch mode during development
 - `npm run test:coverage` - Run tests with coverage reporting
@@ -24,38 +27,43 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 This is an MCP (Model Context Protocol) server that integrates with Mailtrap's email service. The architecture follows a modular pattern:
 
 ### Core Components
+
 - **src/index.ts**: Main MCP server entry point that registers all tools and handles the server lifecycle
 - **src/client.ts**: Mailtrap client configuration and initialization
 - **src/config/index.ts**: Server configuration constants
 
 ### Tool Architecture
+
 All tools follow a consistent pattern in the `src/tools/` directory:
-- Each tool has its own subdirectory (e.g., `sendEmail/`, `templates/`)
-- Tools export both their implementation function and Zod schema for validation
+
+- Each tool (or tool group) has its own subdirectory (e.g., `sendEmail/`, `templates/`, `emailLogs/`)
+- Tools export an **input schema** (JSON Schema–style object for MCP `inputSchema`) and a **handler** function
 - Template operations are grouped under `templates/` with individual files for each CRUD operation
+- **Runtime validation**: Handlers may validate input with Zod (see `stats/schema.ts` and `getSendingStats.ts`). Other tools use TypeScript types and ad-hoc checks; adding Zod validation in handlers is recommended for consistency
 
 ### Tool Structure Pattern
-```
-src/tools/{toolName}/
-├── index.ts          # Main tool export
-├── schema.ts         # Zod validation schema
-├── {toolName}.ts     # Tool implementation
-└── __tests__/        # Jest test files
-```
+
+- Single-tool dirs (e.g. `sendEmail/`, `stats/`): `index.ts`, `schema.ts` (or `schema.ts` + Zod in handler), implementation file(s), `__tests__/`
+- Multi-tool dirs (e.g. `templates/`, `sandbox/`, `emailLogs/`): `index.ts`, `schemas/*.ts` (one schema per tool), implementation file(s), `__tests__/`
+
+Schema files define a JSON Schema–shaped object for MCP; optional Zod schemas in the same or separate file can be used for runtime validation in the handler.
 
 ### Environment Variables Required
+
 - `MAILTRAP_API_TOKEN`: Required API token from Mailtrap
 - `DEFAULT_FROM_EMAIL`: Default sender email address
-- `MAILTRAP_ACCOUNT_ID`: Required for template management and sending stats (optional for send-email only)
+- `MAILTRAP_ACCOUNT_ID`: Required for almost all tools (templates, stats, email logs, sandbox list/show). Optional only for send-email and send-sandbox-email.
 - `MAILTRAP_TEST_INBOX_ID`: Required for sandbox tools - test inbox ID for sandbox mode operations
 
 ### Testing Setup
+
 - Uses Jest with TypeScript support via ts-jest
 - Test files are located in `__tests__/` directories within each tool
 - Environment variables are set up via `jest/setEnvVars.js`
 - Coverage reports exclude test files and type definitions
 
 ### Build Configuration
+
 - TypeScript compilation targets ES2022 with CommonJS modules
 - Separate build config (`tsconfig.build.json`) excludes test files from distribution
 - Output goes to `dist/` directory with proper executable permissions
@@ -63,20 +71,29 @@ src/tools/{toolName}/
 ### Available MCP Tools
 
 #### Transactional Email
-1. **send-email**: Send transactional emails through Mailtrap
 
-#### Email Templates
-2. **create-template**: Create new email templates
-3. **list-templates**: List all email templates
-4. **update-template**: Update existing email templates
-5. **delete-template**: Delete email templates
+- **send-email**: Send transactional emails through Mailtrap.
 
-#### Sandbox Testing
-6. **send-sandbox-email**: Send email in sandbox mode to a test inbox
-7. **get-sandbox-messages**: Get list of messages from the sandbox test inbox
-8. **show-sandbox-email-message**: Show sandbox email message details and content from the sandbox test inbox
+#### Email Logs
+
+- **list-email-logs**: List sent email logs (delivery history) with optional pagination and filters; use to debug delivery issues.
+- **get-email-log-message**: Get a single email log message by ID (UUID) to inspect delivery status and event history; optional `include_content` loads message body when available.
 
 #### Statistics
-9. **get-sending-stats**: Get email sending statistics (delivery, bounce, open, click, spam rates) for a date range; optionally break down by domain, category, email service provider, or date. Requires `MAILTRAP_ACCOUNT_ID`.
 
-Each tool uses Zod schemas for input validation and follows the MCP protocol for response formatting.
+- **get-sending-stats**: Get email sending statistics (delivery, bounce, open, click, spam rates) for a date range; optionally break down by domain, category, email service provider, or date.
+
+#### Email Templates
+
+- **create-template**: Create new email templates.
+- **list-templates**: List all email templates.
+- **update-template**: Update existing email templates.
+- **delete-template**: Delete email templates.
+
+#### Sandbox Testing
+
+- **send-sandbox-email**: Send email in sandbox mode to a test inbox.
+- **get-sandbox-messages**: Get list of messages from the sandbox test inbox.
+- **show-sandbox-email-message**: Show sandbox email message details and content from the sandbox test inbox.
+
+Tools use input schemas (JSON Schema format) for MCP; handlers may validate input with Zod. Response format follows the MCP protocol.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # MCP Mailtrap Server
 
-An MCP server that provides tools for sending transactional emails, managing email templates, checking sending statistics, and testing in sandbox via Mailtrap
+An MCP server that provides tools for sending and testing in sandbox via Mailtrap.
 
 ## Prerequisites
 
@@ -16,10 +16,11 @@ Before using this MCP server, you need to:
 4. Get your Account ID from [Mailtrap account management](https://mailtrap.io/account-management)
 
 **Required Environment Variables:**
+
 - `MAILTRAP_API_TOKEN` - Required for all functionality
 - `DEFAULT_FROM_EMAIL` - Required for all email sending operations
-- `MAILTRAP_ACCOUNT_ID` - Required for template management and sending statistics
-- `MAILTRAP_TEST_INBOX_ID` - **Only** required for sandbox email functionality
+- `MAILTRAP_ACCOUNT_ID` - Required for almost all tools (templates, stats, email logs, sandbox list/show). Optional only for send-email and send-sandbox-email.
+- `MAILTRAP_TEST_INBOX_ID` - Required for sandbox tools (send, list messages, show message)
 
 ## Quick Install
 
@@ -42,7 +43,9 @@ npx @smithery/cli install mailtrap
 
 
 ## Setup
+
 ### Claude Desktop
+
 Use MCPB to install the Mailtrap server. You can find those files in [Releases](https://github.com/mailtrap/mailtrap-mcp/releases). <br>Download .MCPB file and open it. If you have Claude Desktop - it will open it and suggest to configure.
 
 ### Claude Desktop or Cursor
@@ -153,11 +156,23 @@ This creates `mailtrap-mcp.mcpb` using the repository `manifest.json` and built 
 
 Once configured, you can ask agent to send emails and manage templates, for example:
 
-**Email Operations:**
+**Email Sending Operations:**
 
 - "Send an email to john.doe@example.com with the subject 'Meeting Tomorrow' and a friendly reminder about our upcoming meeting."
 - "Email sarah@example.com about the project update, and CC the team at team@example.com"
 - "Send a sandbox email to test@example.com with subject 'Test Template' to preview how our welcome email looks"
+
+**Email Logs (debug delivery):**
+
+- "List my recent sent email logs"
+- "Show email logs for emails sent to user@example.com"
+- "Get the email log message for ID abc-123-uuid to check delivery status"
+
+**Sending Statistics:**
+
+- "Get sending stats for January 2025"
+- "Show delivery rates broken down by domain for last month"
+- "What are my email stats by category from 2025-01-01 to 2025-01-31?"
 
 **Sandbox Operations:**
 
@@ -172,12 +187,6 @@ Once configured, you can ask agent to send emails and manage templates, for exam
 - "Create a new email template called 'Welcome Email' with subject 'Welcome to our platform!'"
 - "Update the template with ID 12345 to change the subject to 'Updated Welcome Message'"
 - "Delete the template with ID 67890"
-
-**Statistics:**
-
-- "Get sending stats for January 2025"
-- "Show delivery rates broken down by domain for last month"
-- "What are my email stats by category from 2025-01-01 to 2025-01-31?"
 
 ## Available Tools
 
@@ -196,47 +205,53 @@ Sends a transactional email through Mailtrap.
 - `bcc` (optional): Array of BCC recipient email addresses
 - `category` (required): Email category for tracking and analytics
 
-### send-sandbox-email
+### list-email-logs
 
-Sends an email to your Mailtrap test inbox for development and testing purposes. This is perfect for testing email templates without sending emails to real recipients.
-
-**Parameters:**
-
-- `to` (required): Email address(es) of the recipient(s) - can be a single email or array of emails (will be delivered to your test inbox)
-- `subject` (required): Email subject line
-- `from` (optional): Email address of the sender, if not provided "DEFAULT_FROM_EMAIL" will be used
-- `text` (optional): Email body text, required if "html" is empty
-- `html` (optional): HTML version of the email body, required if "text" is empty
-- `cc` (optional): Array of CC recipient email addresses
-- `bcc` (optional): Array of BCC recipient email addresses
-- `category` (optional): Email category for tracking
-
-> [!NOTE]
-> The `MAILTRAP_TEST_INBOX_ID` environment variable must be configured for sandbox emails to work. This variable is **only** required for sandbox functionality and is not needed for regular transactional emails or template management.
-
-### get-sandbox-messages
-
-Retrieves a list of messages from your Mailtrap test inbox. Useful for checking what emails have been received in your sandbox during testing.
+Lists sent email logs (delivery history) with optional pagination and filters. Use to debug delivery issues from the IDE.
 
 **Parameters:**
 
-- `page` (optional): Page number for pagination (minimum: 1)
-- `last_id` (optional): Pagination using last message ID. Returns messages after the specified message ID (minimum: 1)
-- `search` (optional): Search query to filter messages
+- `search_after` (optional): Pagination cursor from the previous response's `next_page_cursor`
+- `sent_after` (optional): ISO 8601 date/time; only logs sent after this time
+- `sent_before` (optional): ISO 8601 date/time; only logs sent before this time
+- `from_email` (optional): Filter by sender email; use with `from_operator` (default: ci_equal)
+- `to_email` (optional): Filter by recipient email; use with `to_operator` (default: ci_equal)
+- `status` (optional): Filter by delivery status: delivered, not_delivered, enqueued, opted_out; use with `status_operator` (default: equal)
+- `subject` (optional): Filter by email subject; use with `subject_operator` (default: ci_contain). Use `subject_operator`: empty/not_empty to filter by presence of subject.
+- `sending_domain_id` (optional): Filter by sending domain ID (number); use with `sending_domain_id_operator` (default: equal)
+- `sending_stream` (optional): Filter by stream: transactional or bulk; use with `sending_stream_operator` (default: equal)
+- `events` (optional): Filter by event type(s): delivery, open, click, bounce, spam, unsubscribe, soft_bounce, reject, suspension; use with `events_operator` (include_event / not_include_event)
+- `clicks_count` / `opens_count` (optional): Filter by click/open count; use with `*_operator`: equal, greater_than, less_than
+- `client_ip` / `sending_ip` (optional): Filter by IP; use with `*_operator`: equal, not_equal, contain, not_contain
+- `email_service_provider_response` (optional): Filter by provider response text; use with `*_operator` (ci_contain, etc.)
+- `email_service_provider` (optional): Filter by provider (exact); use with `*_operator`: equal, not_equal
+- `recipient_mx` (optional): Filter by recipient MX; use with `recipient_mx_operator` (ci_contain, etc.)
+- `category` (optional): Filter by email category; use with `category_operator`: equal, not_equal
 
-> [!NOTE]
-> All parameters are optional. If none are provided, the first page of messages from the inbox will be returned. Use page for traditional pagination, last_id for cursor-based pagination, or search to filter messages by content.
+All parameters are optional.
 
-### show-sandbox-email-message
+### get-email-log-message
 
-Shows detailed information and content of a specific email message from your Mailtrap test inbox, including HTML and text body content.
+Gets a single email log message by ID (UUID): a readable summary (from, to, subject, sent time, status, category, stream, engagement, delivery context), then detailed event history. Optionally, with `include_content: true`, you can also load and show the message body (HTML and plain text) when Mailtrap exposes a raw message URL.
 
 **Parameters:**
 
-- `message_id` (required): ID of the sandbox email message to retrieve
+- `message_id` (required): UUID of the email log message (from send response or list-email-logs). Use `list-email-logs` to find message IDs.
+- `include_content` (optional): When `true`, fetches the raw EML (if `raw_message_url` is available) and appends parsed HTML and plain-text body sections, similar to show-sandbox-email-message.
 
-> [!NOTE]
-> Use `get-sandbox-messages` first to get the list of messages and their IDs, then use this tool to view the full content of a specific message.
+### get-sending-stats
+
+Get email sending statistics (delivery, bounce, open, click, spam rates) for a date range. Optionally break down by domain, category, email service provider, or date. Check delivery rates without leaving the editor.
+
+**Parameters:**
+
+- `start_date` (required): Start date for the stats range (YYYY-MM-DD)
+- `end_date` (required): End date for the stats range (YYYY-MM-DD)
+- `breakdown` (optional): How to break down the stats: `aggregated` (default), `by_domain`, `by_category`, `by_email_service_provider`, or `by_date`
+- `sending_domain_ids` (optional): Limit results to these sending domain IDs (array of integers)
+- `sending_streams` (optional): Limit to `transactional` and/or `bulk` (array of strings)
+- `categories` (optional): Limit to these email categories (array of strings)
+- `email_service_providers` (optional): Limit to these providers, e.g. Google, Yahoo, Outlook (array of strings)
 
 ### create-template
 
@@ -282,22 +297,48 @@ Deletes an existing email template.
 
 - `template_id` (required): ID of the template to delete
 
-### get-sending-stats
+### send-sandbox-email
 
-Get email sending statistics (delivery, bounce, open, click, spam rates) for a date range. Optionally break down by domain, category, email service provider, or date. Check delivery rates without leaving the editor.
+Sends an email to your Mailtrap test inbox for development and testing purposes. This is perfect for testing email templates without sending emails to real recipients.
 
 **Parameters:**
 
-- `start_date` (required): Start date for the stats range (YYYY-MM-DD)
-- `end_date` (required): End date for the stats range (YYYY-MM-DD)
-- `breakdown` (optional): How to break down the stats: `aggregated` (default), `by_domain`, `by_category`, `by_email_service_provider`, or `by_date`
-- `sending_domain_ids` (optional): Limit results to these sending domain IDs (array of integers)
-- `sending_streams` (optional): Limit to `transactional` and/or `bulk` (array of strings)
-- `categories` (optional): Limit to these email categories (array of strings)
-- `email_service_providers` (optional): Limit to these providers, e.g. Google, Yahoo, Outlook (array of strings)
+- `to` (required): Email address(es) of the recipient(s) - can be a single email or array of emails (will be delivered to your test inbox)
+- `subject` (required): Email subject line
+- `from` (optional): Email address of the sender, if not provided "DEFAULT_FROM_EMAIL" will be used
+- `text` (optional): Email body text, required if "html" is empty
+- `html` (optional): HTML version of the email body, required if "text" is empty
+- `cc` (optional): Array of CC recipient email addresses
+- `bcc` (optional): Array of BCC recipient email addresses
+- `category` (optional): Email category for tracking
 
 > [!NOTE]
-> `MAILTRAP_ACCOUNT_ID` must be set for this tool to work.
+> The `MAILTRAP_TEST_INBOX_ID` environment variable must be configured for sandbox emails to work. This variable is **only** required for sandbox functionality and is not needed for regular transactional emails or template management.
+
+### get-sandbox-messages
+
+Retrieves a list of messages from your Mailtrap test inbox. Useful for checking what emails have been received in your sandbox during testing.
+
+**Parameters:**
+
+- `page` (optional): Page number for pagination (minimum: 1)
+- `last_id` (optional): Pagination using last message ID. Returns messages after the specified message ID (minimum: 1)
+- `search` (optional): Search query to filter messages
+
+> [!NOTE]
+> All parameters are optional. If none are provided, the first page of messages from the inbox will be returned. Use page for traditional pagination, last_id for cursor-based pagination, or search to filter messages by content.
+
+### show-sandbox-email-message
+
+Shows detailed information and content of a specific email message from your Mailtrap test inbox, including HTML and text body content.
+
+**Parameters:**
+
+- `message_id` (required): ID of the sandbox email message to retrieve
+
+> [!NOTE]
+> Use `get-sandbox-messages` first to get the list of messages and their IDs, then use this tool to view the full content of a specific message.
+
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.2",
         "dotenv": "^16.4.7",
-        "mailtrap": "^4.5.0",
+        "mailsplit": "^5.4.6",
+        "mailtrap": "^4.5.1",
         "zod": "^3.24.2"
       },
       "bin": {
@@ -4442,6 +4443,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding-japanese": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
+      "integrity": "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -7461,6 +7471,42 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libbase64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-1.3.0.tgz",
+      "integrity": "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg==",
+      "license": "MIT"
+    },
+    "node_modules/libmime": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.7.tgz",
+      "integrity": "sha512-FlDb3Wtha8P01kTL3P9M+ZDNDWPKPmKHWaU/cG/lg5pfuAwdflVpZE+wm9m7pKmC5ww6s+zTxBKS1p6yl3KpSw==",
+      "license": "MIT",
+      "dependencies": {
+        "encoding-japanese": "2.2.0",
+        "iconv-lite": "0.6.3",
+        "libbase64": "1.3.0",
+        "libqp": "2.1.1"
+      }
+    },
+    "node_modules/libmime/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/libqp": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/libqp/-/libqp-2.1.1.tgz",
+      "integrity": "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==",
+      "license": "MIT"
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -7531,10 +7577,22 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/mailsplit": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/mailsplit/-/mailsplit-5.4.6.tgz",
+      "integrity": "sha512-M+cqmzaPG/mEiCDmqQUz8L177JZLZmXAUpq38owtpq2xlXlTSw+kntnxRt2xsxVFFV6+T8Mj/U0l5s7s6e0rNw==",
+      "deprecated": "This package has been renamed to @zone-eu/mailsplit. Please update your dependencies.",
+      "license": "(MIT OR EUPL-1.1+)",
+      "dependencies": {
+        "libbase64": "1.3.0",
+        "libmime": "5.3.7",
+        "libqp": "2.1.1"
+      }
+    },
     "node_modules/mailtrap": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mailtrap/-/mailtrap-4.5.0.tgz",
-      "integrity": "sha512-ebywWiTdw38mHSuG2q4GJ1tWqc5cDhs4SYZFHWVk12kq5TfqUFY0O7EqvQCPJ97GF9F139s7+1/a/vWDvHY5mg==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/mailtrap/-/mailtrap-4.5.1.tgz",
+      "integrity": "sha512-ABMvAk41q9iteM3Iga9ZaNrR/3RppGEPcYihihv6qnwvmFcE16mKcXSbuIRl3V5tRR5ZRQ4+BuUeZO2Y9xuxRA==",
       "license": "MIT",
       "dependencies": {
         "axios": ">=0.27",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.18.2",
     "dotenv": "^16.4.7",
-    "mailtrap": "^4.5.0",
+    "mailsplit": "^5.4.6",
+    "mailtrap": "^4.5.1",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/src/mailsplit.d.ts
+++ b/src/mailsplit.d.ts
@@ -1,0 +1,16 @@
+declare module "mailsplit" {
+  import { Transform } from "stream";
+
+  export class Splitter extends Transform {
+    on(event: "data", listener: (data: SplitterData) => void): this;
+    on(event: "end", listener: () => void): this;
+    on(event: "error", listener: (err: Error) => void): this;
+  }
+
+  export interface SplitterData {
+    type: "node" | "body" | "data";
+    contentType?: string;
+    value?: Buffer;
+    getDecoder?: () => NodeJS.ReadWriteStream;
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,12 @@ import {
   showEmailMessageSchema,
 } from "./tools/sandbox";
 import { getSendingStats, getSendingStatsSchema } from "./tools/stats";
+import {
+  listEmailLogs,
+  listEmailLogsSchema,
+  getEmailLogMessage,
+  getEmailLogMessageSchema,
+} from "./tools/emailLogs";
 
 // Define the tools registry
 const tools = [
@@ -109,6 +115,26 @@ const tools = [
       "Get email sending statistics (delivery, bounce, open, click, spam rates) for a date range. Optionally break down by domain, category, email service provider, or date.",
     inputSchema: getSendingStatsSchema,
     handler: getSendingStats,
+    annotations: {
+      readOnlyHint: true,
+    },
+  },
+  {
+    name: "list-email-logs",
+    description:
+      "List sent email logs (delivery history) with optional pagination and filters; use to debug delivery issues.",
+    inputSchema: listEmailLogsSchema,
+    handler: listEmailLogs,
+    annotations: {
+      readOnlyHint: true,
+    },
+  },
+  {
+    name: "get-email-log-message",
+    description:
+      "Get a single email log message by ID (UUID) to inspect delivery status and event history.",
+    inputSchema: getEmailLogMessageSchema,
+    handler: getEmailLogMessage,
     annotations: {
       readOnlyHint: true,
     },

--- a/src/tools/emailLogs/__tests__/emailLogEventFormat.test.ts
+++ b/src/tools/emailLogs/__tests__/emailLogEventFormat.test.ts
@@ -1,0 +1,55 @@
+import { formatEmailLogEvent } from "../utils/emailLogEventFormat";
+
+describe("emailLogEventFormat", () => {
+  describe("formatEmailLogEvent", () => {
+    it("formats delivery with detail lines", () => {
+      const text = formatEmailLogEvent({
+        event_type: "delivery",
+        created_at: "2024-01-01T12:00:01Z",
+        details: {
+          sending_ip: "203.0.113.1",
+          recipient_mx: "mx.example.com",
+          email_service_provider: "Example ESP",
+        },
+      });
+      expect(text).toContain("delivery: 2024-01-01T12:00:01Z");
+      expect(text).toContain("Sending IP: 203.0.113.1");
+      expect(text).toContain("Recipient mail server (MX): mx.example.com");
+      expect(text).toContain("Mailbox provider: Example ESP");
+    });
+
+    it("formats open with client IP", () => {
+      const text = formatEmailLogEvent({
+        event_type: "open",
+        created_at: "2024-01-01T12:00:05Z",
+        details: { web_ip_address: "198.51.100.2" },
+      });
+      expect(text).toContain("open: 2024-01-01T12:00:05Z");
+      expect(text).toContain("Client IP: 198.51.100.2");
+    });
+
+    it("formats soft_bounce with provider response fields", () => {
+      const text = formatEmailLogEvent({
+        event_type: "soft_bounce",
+        created_at: "2024-01-01T13:00:00Z",
+        details: {
+          sending_ip: "203.0.113.9",
+          recipient_mx: "mx.bounce.example",
+          email_service_provider: "Bounce ESP",
+          email_service_provider_status: "550",
+          email_service_provider_response: "Mailbox unavailable",
+          bounce_category: "hard",
+        },
+      });
+      expect(text).toContain("soft_bounce: 2024-01-01T13:00:00Z");
+      expect(text).toContain("Sending IP: 203.0.113.9");
+      expect(text).toContain("Provider response: Mailbox unavailable");
+    });
+
+    it("formats unrecognized event as JSON", () => {
+      const text = formatEmailLogEvent({ foo: "bar" });
+      expect(text).toContain("(unrecognized event)");
+      expect(text).toContain("foo");
+    });
+  });
+});

--- a/src/tools/emailLogs/__tests__/emailLogMessageSummary.test.ts
+++ b/src/tools/emailLogs/__tests__/emailLogMessageSummary.test.ts
@@ -1,0 +1,61 @@
+import {
+  buildMessageSummaryLines,
+  disp,
+} from "../utils/emailLogMessageSummary";
+import mockEmailLogWithEvents from "../fixtures/emailLogMessageFixtures";
+
+describe("emailLogMessageSummary", () => {
+  describe("disp", () => {
+    it("returns em dash for nullish and empty string", () => {
+      expect(disp(null)).toBe("—");
+      expect(disp(undefined)).toBe("—");
+      expect(disp("")).toBe("—");
+    });
+
+    it("stringifies other values", () => {
+      expect(disp("x")).toBe("x");
+      expect(disp(42)).toBe("42");
+      expect(disp(true)).toBe("true");
+    });
+  });
+
+  describe("buildMessageSummaryLines", () => {
+    it("builds human-readable lines from log entry", () => {
+      const lines = buildMessageSummaryLines(mockEmailLogWithEvents);
+      const text = lines.join("\n");
+      expect(text).toContain("From: sender@example.com");
+      expect(text).toContain("To: user@example.com");
+      expect(text).toContain("Subject: Welcome");
+      expect(text).toContain("Sent: 2024-01-01T12:00:00Z");
+      expect(text).toContain("Status: delivered");
+      expect(text).toContain("Opens: 3 · Link clicks: 1");
+      expect(text).toContain("Events recorded: delivery, open");
+      expect(text).toContain("Sending IP: 203.0.113.1");
+      expect(text).toContain("Recipient mail server (MX): mx.example.com");
+      expect(text).toContain("Mailbox provider: Example ESP");
+    });
+
+    it("includes bounce provider response from soft_bounce event", () => {
+      const lines = buildMessageSummaryLines({
+        ...mockEmailLogWithEvents,
+        events: [
+          {
+            event_type: "soft_bounce",
+            created_at: "2024-01-01T13:00:00Z",
+            details: {
+              sending_ip: "203.0.113.9",
+              recipient_mx: "mx.bounce.example",
+              email_service_provider: "Bounce ESP",
+              email_service_provider_status: "550",
+              email_service_provider_response: "Mailbox unavailable",
+              bounce_category: "hard",
+            },
+          },
+        ],
+      });
+      expect(lines.join("\n")).toContain(
+        "Bounce / provider response: Mailbox unavailable"
+      );
+    });
+  });
+});

--- a/src/tools/emailLogs/__tests__/getEmailLogMessage.includeContent.test.ts
+++ b/src/tools/emailLogs/__tests__/getEmailLogMessage.includeContent.test.ts
@@ -1,0 +1,167 @@
+import getEmailLogMessage from "../getEmailLogMessage";
+import { client } from "../../../client";
+import mockEmailLogWithEvents from "../fixtures/emailLogMessageFixtures";
+
+jest.mock("../../../client", () => ({
+  client: {
+    emailLogs: {
+      get: jest.fn(),
+    },
+  },
+}));
+
+describe("getEmailLogMessage include_content", () => {
+  const rawUrl = "https://api.mailtrap.io/raw/eml/msg-123";
+  const originalEnv = { ...process.env };
+
+  function multipartEml(): Buffer {
+    const lines = [
+      "From: a@b.c",
+      "To: x@y.z",
+      "Subject: T",
+      "MIME-Version: 1.0",
+      'Content-Type: multipart/alternative; boundary="b"',
+      "",
+      "--b",
+      "Content-Type: text/plain; charset=UTF-8",
+      "",
+      "Hello plain",
+      "--b",
+      "Content-Type: text/html; charset=UTF-8",
+      "",
+      "<p>Hello html</p>",
+      "--b--",
+    ];
+    return Buffer.from(lines.join("\r\n"), "utf8");
+  }
+
+  function toArrayBuffer(buf: Buffer): ArrayBuffer {
+    return buf.buffer.slice(
+      buf.byteOffset,
+      buf.byteOffset + buf.byteLength
+    ) as ArrayBuffer;
+  }
+
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.assign(process.env, { MAILTRAP_ACCOUNT_ID: "456" });
+    (client as any).emailLogs.get.mockResolvedValue(mockEmailLogWithEvents);
+    fetchSpy = jest.spyOn(global, "fetch").mockImplementation();
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    Object.assign(process.env, originalEnv);
+  });
+
+  it("should not fetch when include_content is false", async () => {
+    await getEmailLogMessage({
+      message_id: "msg-uuid-123",
+      include_content: false,
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("should not fetch when raw_message_url is missing", async () => {
+    await getEmailLogMessage({
+      message_id: "msg-uuid-123",
+      include_content: true,
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("should fetch raw message URL and append parsed HTML and text bodies", async () => {
+    (client as any).emailLogs.get.mockResolvedValue({
+      ...mockEmailLogWithEvents,
+      raw_message_url: rawUrl,
+    });
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => toArrayBuffer(multipartEml()),
+    } as Response);
+
+    const result = await getEmailLogMessage({
+      message_id: "msg-uuid-123",
+      include_content: true,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith(rawUrl, {
+      signal: expect.any(AbortSignal),
+    });
+
+    expect(result.content[0].text).toContain("Email Log Details");
+    expect(result.content[0].text).toContain("--- HTML Content ---");
+    expect(result.content[0].text).toContain("<p>Hello html</p>");
+    expect(result.content[0].text).toContain("--- Text Content ---");
+    expect(result.content[0].text).toContain("Hello plain");
+  });
+
+  it("should report fetch failure status when response not ok", async () => {
+    (client as any).emailLogs.get.mockResolvedValue({
+      ...mockEmailLogWithEvents,
+      raw_message_url: rawUrl,
+    });
+    fetchSpy.mockResolvedValue({
+      ok: false,
+      status: 403,
+    } as Response);
+
+    const result = await getEmailLogMessage({
+      message_id: "msg-uuid-123",
+      include_content: true,
+    });
+
+    expect(result.content[0].text).toContain("Failed to fetch (403)");
+  });
+
+  it("should report fetch/parse errors in content", async () => {
+    (client as any).emailLogs.get.mockResolvedValue({
+      ...mockEmailLogWithEvents,
+      raw_message_url: rawUrl,
+    });
+    fetchSpy.mockRejectedValue(new Error("network down"));
+
+    const result = await getEmailLogMessage({
+      message_id: "msg-uuid-123",
+      include_content: true,
+    });
+
+    expect(result.content[0].text).toContain("Error fetching or parsing");
+    expect(result.content[0].text).toContain("network down");
+  });
+
+  it("should report when EML has no text or html parts", async () => {
+    (client as any).emailLogs.get.mockResolvedValue({
+      ...mockEmailLogWithEvents,
+      raw_message_url: rawUrl,
+    });
+    const emptyMime = Buffer.from(
+      [
+        "From: a@b.c",
+        "To: x@y.z",
+        "Subject: T",
+        "MIME-Version: 1.0",
+        "Content-Type: application/octet-stream",
+        "",
+        "binary only",
+      ].join("\r\n"),
+      "utf8"
+    );
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => toArrayBuffer(emptyMime),
+    } as Response);
+
+    const result = await getEmailLogMessage({
+      message_id: "msg-uuid-123",
+      include_content: true,
+    });
+
+    expect(result.content[0].text).toContain(
+      "No HTML or text body found in message"
+    );
+  });
+});

--- a/src/tools/emailLogs/__tests__/getEmailLogMessage.test.ts
+++ b/src/tools/emailLogs/__tests__/getEmailLogMessage.test.ts
@@ -1,0 +1,113 @@
+import getEmailLogMessage from "../getEmailLogMessage";
+import { client } from "../../../client";
+import mockEmailLogWithEvents from "../fixtures/emailLogMessageFixtures";
+
+jest.mock("../../../client", () => ({
+  client: {
+    emailLogs: {
+      get: jest.fn(),
+    },
+  },
+}));
+
+describe("getEmailLogMessage", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.assign(process.env, { MAILTRAP_ACCOUNT_ID: "456" });
+    (client as any).emailLogs.get.mockResolvedValue(mockEmailLogWithEvents);
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, originalEnv);
+  });
+
+  it("should get email log message successfully", async () => {
+    const result = await getEmailLogMessage({ message_id: "msg-uuid-123" });
+
+    expect((client as any).emailLogs.get).toHaveBeenCalledWith("msg-uuid-123");
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe("text");
+    expect(result.content[0].text).toContain("Email Log Details");
+    expect(result.content[0].text).toContain("msg-uuid-123");
+    expect(result.content[0].text).toContain("Event history");
+    expect(result.content[0].text).toContain("delivery: 2024-01-01T12:00:01Z");
+    expect(result.content[0].text).toContain("open: 2024-01-01T12:00:05Z");
+  });
+
+  it("should handle not found", async () => {
+    (client as any).emailLogs.get.mockResolvedValue(null);
+
+    const result = await getEmailLogMessage({ message_id: "missing-uuid" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("not found");
+  });
+
+  it("should require MAILTRAP_ACCOUNT_ID", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    delete process.env.MAILTRAP_ACCOUNT_ID;
+
+    const result = await getEmailLogMessage({ message_id: "msg-uuid-123" });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error getting email log message:",
+      expect.anything()
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("MAILTRAP_ACCOUNT_ID");
+    expect((client as any).emailLogs.get).not.toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should require valid MAILTRAP_ACCOUNT_ID", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    process.env.MAILTRAP_ACCOUNT_ID = "invalid";
+
+    const result = await getEmailLogMessage({ message_id: "msg-uuid-123" });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error getting email log message:",
+      expect.anything()
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("MAILTRAP_ACCOUNT_ID");
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should handle API errors", async () => {
+    const mockError = new Error("Not found");
+    (client as any).emailLogs.get.mockRejectedValue(mockError);
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const result = await getEmailLogMessage({ message_id: "msg-uuid-123" });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error getting email log message:",
+      mockError
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Failed to get email log message");
+    expect(result.content[0].text).toContain("Not found");
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should include error field when present in log", async () => {
+    (client as any).emailLogs.get.mockResolvedValue({
+      ...mockEmailLogWithEvents,
+      error: "Recipient mailbox full",
+    });
+
+    const result = await getEmailLogMessage({ message_id: "msg-uuid-123" });
+
+    expect(result.content[0].text).toContain("Error:");
+    expect(result.content[0].text).toContain("Recipient mailbox full");
+  });
+});

--- a/src/tools/emailLogs/__tests__/listEmailLogs.test.ts
+++ b/src/tools/emailLogs/__tests__/listEmailLogs.test.ts
@@ -1,0 +1,191 @@
+import listEmailLogs from "../listEmailLogs";
+import { client } from "../../../client";
+
+jest.mock("../../../client", () => ({
+  client: {
+    emailLogs: {
+      getList: jest.fn(),
+    },
+  },
+}));
+
+describe("listEmailLogs", () => {
+  const mockLogs = [
+    {
+      id: "msg-uuid-1",
+      status: "delivered",
+      from: "sender@example.com",
+      to: "user@example.com",
+      subject: "Test 1",
+      sent_at: "2024-01-01T12:00:00Z",
+    },
+    {
+      id: "msg-uuid-2",
+      status: "bounced",
+      from: "noreply@example.com",
+      to: "invalid@example.com",
+      subject: "Test 2",
+      sent_at: "2024-01-02T12:00:00Z",
+    },
+  ];
+
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.assign(process.env, { MAILTRAP_ACCOUNT_ID: "456" });
+    (client as any).emailLogs.getList.mockResolvedValue({ messages: mockLogs });
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, originalEnv);
+  });
+
+  it("should list email logs successfully", async () => {
+    const result = await listEmailLogs({});
+
+    expect((client as any).emailLogs.getList).toHaveBeenCalledWith(undefined);
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe("text");
+    expect(result.content[0].text).toContain("Found 2 email log message(s)");
+    expect(result.content[0].text).toContain("msg-uuid-1");
+    expect(result.content[0].text).toContain("delivered");
+    expect(result.content[0].text).toContain("sender@example.com");
+    expect(result.content[0].text).toContain("user@example.com");
+    expect(result.content[0].text).toContain("Test 1");
+  });
+
+  it("should handle empty logs list", async () => {
+    (client as any).emailLogs.getList.mockResolvedValue({ messages: [] });
+
+    const result = await listEmailLogs({});
+
+    expect(result.content[0].text).toContain("No email log messages found");
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("should require MAILTRAP_ACCOUNT_ID", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    delete process.env.MAILTRAP_ACCOUNT_ID;
+
+    const result = await listEmailLogs({});
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error listing email log messages:",
+      expect.anything()
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("MAILTRAP_ACCOUNT_ID");
+    expect((client as any).emailLogs.getList).not.toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should require valid MAILTRAP_ACCOUNT_ID", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    process.env.MAILTRAP_ACCOUNT_ID = "not-a-number";
+
+    const result = await listEmailLogs({});
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error listing email log messages:",
+      expect.anything()
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("MAILTRAP_ACCOUNT_ID");
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should pass search_after to getList", async () => {
+    await listEmailLogs({ search_after: "cursor-abc" });
+
+    expect((client as any).emailLogs.getList).toHaveBeenCalledWith({
+      search_after: "cursor-abc",
+    });
+  });
+
+  it("should pass filters with operator to getList", async () => {
+    await listEmailLogs({
+      sent_after: "2024-01-01T00:00:00Z",
+      from_email: "noreply@example.com",
+      status: "delivered",
+    });
+
+    expect((client as any).emailLogs.getList).toHaveBeenCalledWith({
+      filters: {
+        sent_after: "2024-01-01T00:00:00Z",
+        from: { operator: "ci_equal", value: "noreply@example.com" },
+        status: { operator: "equal", value: "delivered" },
+      },
+    });
+  });
+
+  it("should pass explicit from_operator and status_operator to getList", async () => {
+    await listEmailLogs({
+      from_email: "user@example.com",
+      from_operator: "ci_contain",
+      status: "not_delivered",
+      status_operator: "not_equal",
+    });
+
+    expect((client as any).emailLogs.getList).toHaveBeenCalledWith({
+      filters: {
+        from: { operator: "ci_contain", value: "user@example.com" },
+        status: { operator: "not_equal", value: "not_delivered" },
+      },
+    });
+  });
+
+  it("should pass multiple category values as array to getList", async () => {
+    await listEmailLogs({
+      category: ["Newsletter", "Alert"],
+      category_operator: "equal",
+    });
+
+    expect((client as any).emailLogs.getList).toHaveBeenCalledWith({
+      filters: {
+        category: {
+          operator: "equal",
+          value: ["Newsletter", "Alert"],
+        },
+      },
+    });
+  });
+
+  it("should handle API errors", async () => {
+    const mockError = new Error("API Error");
+    (client as any).emailLogs.getList.mockRejectedValue(mockError);
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const result = await listEmailLogs({});
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error listing email log messages:",
+      mockError
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(
+      "Failed to list email log messages"
+    );
+    expect(result.content[0].text).toContain("API Error");
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should include next_page_cursor when present", async () => {
+    (client as any).emailLogs.getList.mockResolvedValue({
+      messages: mockLogs,
+      next_page_cursor: "next-cursor-xyz",
+    });
+
+    const result = await listEmailLogs({});
+
+    expect(result.content[0].text).toContain("Next page");
+    expect(result.content[0].text).toContain("search_after");
+    expect(result.content[0].text).toContain("next-cursor-xyz");
+  });
+});

--- a/src/tools/emailLogs/__tests__/parseEmlBuffer.test.ts
+++ b/src/tools/emailLogs/__tests__/parseEmlBuffer.test.ts
@@ -1,0 +1,48 @@
+import parseEmlBuffer from "../utils/parseEmlBuffer";
+
+function multipartEml(): Buffer {
+  const lines = [
+    "From: a@b.c",
+    "To: x@y.z",
+    "Subject: T",
+    "MIME-Version: 1.0",
+    'Content-Type: multipart/alternative; boundary="b"',
+    "",
+    "--b",
+    "Content-Type: text/plain; charset=UTF-8",
+    "",
+    "Hello plain",
+    "--b",
+    "Content-Type: text/html; charset=UTF-8",
+    "",
+    "<p>Hello html</p>",
+    "--b--",
+  ];
+  return Buffer.from(lines.join("\r\n"), "utf8");
+}
+
+describe("parseEmlBuffer", () => {
+  it("extracts html and plain from multipart/alternative", async () => {
+    const { htmlContent, textContent } = await parseEmlBuffer(multipartEml());
+    expect(htmlContent).toContain("<p>Hello html</p>");
+    expect(textContent).toContain("Hello plain");
+  });
+
+  it("returns empty html and text when no text parts", async () => {
+    const emptyMime = Buffer.from(
+      [
+        "From: a@b.c",
+        "To: x@y.z",
+        "Subject: T",
+        "MIME-Version: 1.0",
+        "Content-Type: application/octet-stream",
+        "",
+        "binary only",
+      ].join("\r\n"),
+      "utf8"
+    );
+    const { htmlContent, textContent } = await parseEmlBuffer(emptyMime);
+    expect(htmlContent).toBe("");
+    expect(textContent).toBe("");
+  });
+});

--- a/src/tools/emailLogs/fixtures/emailLogMessageFixtures.ts
+++ b/src/tools/emailLogs/fixtures/emailLogMessageFixtures.ts
@@ -1,0 +1,38 @@
+import type { EmailLogMessageDetails } from "../../../types/mailtrap";
+
+/** Shared row matching `client.emailLogs.get()` (mailtrap SDK). */
+const mockEmailLogWithEvents: EmailLogMessageDetails = {
+  message_id: "msg-uuid-123",
+  status: "delivered",
+  from: "sender@example.com",
+  to: "user@example.com",
+  subject: "Welcome",
+  sent_at: "2024-01-01T12:00:00Z",
+  client_ip: "192.0.2.10",
+  category: "Onboarding",
+  custom_variables: {},
+  sending_domain_id: 42,
+  sending_stream: "transactional",
+  template_id: null,
+  template_variables: {},
+  opens_count: 3,
+  clicks_count: 1,
+  events: [
+    {
+      event_type: "delivery",
+      created_at: "2024-01-01T12:00:01Z",
+      details: {
+        sending_ip: "203.0.113.1",
+        recipient_mx: "mx.example.com",
+        email_service_provider: "Example ESP",
+      },
+    },
+    {
+      event_type: "open",
+      created_at: "2024-01-01T12:00:05Z",
+      details: { web_ip_address: "198.51.100.2" },
+    },
+  ],
+};
+
+export default mockEmailLogWithEvents;

--- a/src/tools/emailLogs/getEmailLogMessage.ts
+++ b/src/tools/emailLogs/getEmailLogMessage.ts
@@ -1,0 +1,139 @@
+import { client } from "../../client";
+import { type EmailLogMessageDetails } from "../../types/mailtrap";
+import { formatEmailLogEvent } from "./utils/emailLogEventFormat";
+import { buildMessageSummaryLines } from "./utils/emailLogMessageSummary";
+import { getEmailLogMessageZod } from "./schemas/getEmailLogMessage";
+import parseEmlBuffer from "./utils/parseEmlBuffer";
+
+/** API may include an error summary on the row (not always in SDK typings). */
+type EmailLogMessageRow = EmailLogMessageDetails & { error?: string };
+
+async function getEmailLogMessage(raw: unknown): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    const parsed = getEmailLogMessageZod.safeParse(raw);
+    if (!parsed.success) {
+      const msg = parsed.error.errors
+        .map((e) => `${e.path.join(".")}: ${e.message}`)
+        .join("; ");
+      return {
+        content: [{ type: "text", text: `Invalid input: ${msg}` }],
+        isError: true,
+      };
+    }
+
+    const { message_id: messageId, include_content: includeContent } =
+      parsed.data;
+
+    if (!client) {
+      throw new Error("MAILTRAP_API_TOKEN environment variable is required");
+    }
+
+    if (
+      !process.env.MAILTRAP_ACCOUNT_ID ||
+      Number.isNaN(Number(process.env.MAILTRAP_ACCOUNT_ID))
+    ) {
+      throw new Error(
+        "MAILTRAP_ACCOUNT_ID environment variable is required for email logs. Find it at https://mailtrap.io/account-management"
+      );
+    }
+
+    const log = (await client.emailLogs.get(
+      messageId
+    )) as EmailLogMessageRow | null;
+
+    if (log == null) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Email log with message ID ${messageId} not found.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const lines = [
+      `Message ID: ${log.message_id}`,
+      "",
+      ...buildMessageSummaryLines(log),
+    ];
+
+    if (log.events?.length) {
+      lines.push(
+        "",
+        "Event history:",
+        ...log.events.map((e) => formatEmailLogEvent(e))
+      );
+    }
+
+    if (log.error) {
+      lines.push("", `Error: ${log.error}`);
+    }
+
+    let contentText = `Email Log Details:\n\n${lines.join("\n")}`;
+
+    if (includeContent && log.raw_message_url) {
+      const RAW_FETCH_TIMEOUT_MS = 60_000;
+      const controller = new AbortController();
+      const timeoutId = setTimeout(
+        () => controller.abort(),
+        RAW_FETCH_TIMEOUT_MS
+      );
+      try {
+        const rawResponse = await fetch(log.raw_message_url, {
+          signal: controller.signal,
+        });
+        clearTimeout(timeoutId);
+        if (!rawResponse.ok) {
+          contentText += `\n\nRaw content: Failed to fetch (${rawResponse.status}).`;
+        } else {
+          const rawBuffer = Buffer.from(await rawResponse.arrayBuffer());
+          const { htmlContent, textContent } = await parseEmlBuffer(rawBuffer);
+          if (htmlContent) {
+            contentText += `\n\n--- HTML Content ---\n${htmlContent}`;
+          }
+          if (textContent) {
+            contentText += `\n\n--- Text Content ---\n${textContent}`;
+          }
+          if (!htmlContent && !textContent) {
+            contentText +=
+              "\n\nRaw content: No HTML or text body found in message.";
+          }
+        }
+      } catch (rawErr) {
+        clearTimeout(timeoutId);
+        let rawErrMsg: string;
+        if (rawErr instanceof Error && rawErr.name === "AbortError") {
+          rawErrMsg = "Request timed out.";
+        } else {
+          rawErrMsg = rawErr instanceof Error ? rawErr.message : String(rawErr);
+        }
+        contentText += `\n\nRaw content: Error fetching or parsing — ${rawErrMsg}`;
+      }
+    }
+
+    return {
+      content: [{ type: "text", text: contentText }],
+    };
+  } catch (error) {
+    console.error("Error getting email log message:", error);
+
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to get email log message: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default getEmailLogMessage;

--- a/src/tools/emailLogs/index.ts
+++ b/src/tools/emailLogs/index.ts
@@ -1,0 +1,11 @@
+import listEmailLogsSchema from "./schemas/listEmailLogs";
+import listEmailLogs from "./listEmailLogs";
+import getEmailLogMessageSchema from "./schemas/getEmailLogMessage";
+import getEmailLogMessage from "./getEmailLogMessage";
+
+export {
+  listEmailLogsSchema,
+  listEmailLogs,
+  getEmailLogMessageSchema,
+  getEmailLogMessage,
+};

--- a/src/tools/emailLogs/listEmailLogs.ts
+++ b/src/tools/emailLogs/listEmailLogs.ts
@@ -1,0 +1,310 @@
+import { client } from "../../client";
+import type { EmailLogMessageDetails } from "../../types/mailtrap";
+import {
+  listEmailLogsZod,
+  listEmailLogsResponseZod,
+} from "./schemas/listEmailLogs";
+import { buildMessageSummaryLines } from "./utils/emailLogMessageSummary";
+
+/** Normalize to array. Only splits on commas when allowCommaSplit is true. */
+function toValueArray(
+  v: string | string[] | undefined,
+  allowCommaSplit = false
+): string[] | undefined {
+  if (v === undefined) return undefined;
+  if (Array.isArray(v)) return v.length > 0 ? v : undefined;
+  const trimmed = String(v).trim();
+  if (!trimmed) return undefined;
+  if (allowCommaSplit && trimmed.includes(",")) {
+    return trimmed
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  return [trimmed];
+}
+
+/** Normalize number or number[] to array. */
+function toNumberArray(v: number | number[] | undefined): number[] | undefined {
+  if (v === undefined) return undefined;
+  if (Array.isArray(v)) return v.length > 0 ? v : undefined;
+  return [v];
+}
+
+/** Operators that support multiple values (array); others require single value. */
+const MULTI_VALUE_OPERATORS = new Set([
+  "equal",
+  "not_equal",
+  "ci_equal",
+  "ci_not_equal",
+]);
+
+function filterValue<T>(values: T[], operator: string | undefined): T | T[] {
+  if (values.length > 1) {
+    const multi = operator !== undefined && MULTI_VALUE_OPERATORS.has(operator);
+    if (!multi) {
+      throw new Error(
+        `Invalid multi-value/operator combination: multiple values provided but operator "${
+          operator ?? "undefined"
+        }" does not support multiple values.`
+      );
+    }
+    return values;
+  }
+  return values[0];
+}
+
+async function listEmailLogs(raw: unknown): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    const parsed = listEmailLogsZod.safeParse(raw);
+    if (!parsed.success) {
+      const msg = parsed.error.errors
+        .map((e) => `${e.path.join(".")}: ${e.message}`)
+        .join("; ");
+      return {
+        content: [{ type: "text", text: `Invalid input: ${msg}` }],
+        isError: true,
+      };
+    }
+
+    const params = parsed.data;
+
+    if (!client) {
+      throw new Error("MAILTRAP_API_TOKEN environment variable is required");
+    }
+
+    if (
+      !process.env.MAILTRAP_ACCOUNT_ID ||
+      Number.isNaN(Number(process.env.MAILTRAP_ACCOUNT_ID))
+    ) {
+      throw new Error(
+        "MAILTRAP_ACCOUNT_ID environment variable is required for email logs. Find it at https://mailtrap.io/account-management"
+      );
+    }
+
+    type FilterWithValue =
+      | { operator: string; value?: string | string[] }
+      | { operator: string; value: number | number[] };
+    type Filters = Record<string, string | FilterWithValue>;
+    const filters: Filters = {};
+    if (params.sent_after !== undefined) filters.sent_after = params.sent_after;
+    if (params.sent_before !== undefined)
+      filters.sent_before = params.sent_before;
+    const fromVal = toValueArray(params.from_email, true);
+    if (fromVal !== undefined) {
+      filters.from = {
+        operator: params.from_operator ?? "ci_equal",
+        value: filterValue(fromVal, params.from_operator ?? "ci_equal"),
+      };
+    }
+    const toVal = toValueArray(params.to_email, true);
+    if (toVal !== undefined) {
+      filters.to = {
+        operator: params.to_operator ?? "ci_equal",
+        value: filterValue(toVal, params.to_operator ?? "ci_equal"),
+      };
+    }
+    let statusArr: string[] | undefined;
+    if (Array.isArray(params.status)) {
+      statusArr = params.status.length > 0 ? params.status : undefined;
+    } else if (params.status !== undefined) {
+      statusArr = [params.status];
+    }
+    if (statusArr !== undefined) {
+      filters.status = {
+        operator: params.status_operator ?? "equal",
+        value: filterValue(statusArr, params.status_operator ?? "equal"),
+      };
+    }
+    if (
+      params.subject_operator === "empty" ||
+      params.subject_operator === "not_empty"
+    ) {
+      filters.subject = { operator: params.subject_operator };
+    } else if (params.subject !== undefined) {
+      const subjectVal = toValueArray(params.subject);
+      if (subjectVal !== undefined) {
+        const op = params.subject_operator ?? "ci_contain";
+        filters.subject = {
+          operator: op,
+          value: filterValue(subjectVal, op),
+        };
+      }
+    }
+    const domainIdVal = toNumberArray(params.sending_domain_id);
+    if (domainIdVal !== undefined) {
+      const op = params.sending_domain_id_operator ?? "equal";
+      filters.sending_domain_id = {
+        operator: op,
+        value: filterValue(domainIdVal, op),
+      };
+    }
+    let streamArr: ("transactional" | "bulk")[] | undefined;
+    if (Array.isArray(params.sending_stream)) {
+      streamArr =
+        params.sending_stream.length > 0 ? params.sending_stream : undefined;
+    } else if (params.sending_stream !== undefined) {
+      streamArr = [params.sending_stream];
+    }
+    if (streamArr !== undefined) {
+      const op = params.sending_stream_operator ?? "equal";
+      filters.sending_stream = {
+        operator: op,
+        value: filterValue(streamArr, op),
+      };
+    }
+    if (
+      params.events !== undefined &&
+      (Array.isArray(params.events) ? params.events.length > 0 : true)
+    ) {
+      const eventValues = Array.isArray(params.events)
+        ? params.events
+        : [params.events];
+      filters.events = {
+        operator: params.events_operator ?? "include_event",
+        value: eventValues,
+      };
+    }
+    if (params.clicks_count !== undefined) {
+      filters.clicks_count = {
+        operator: params.clicks_count_operator ?? "equal",
+        value: params.clicks_count,
+      };
+    }
+    if (params.opens_count !== undefined) {
+      filters.opens_count = {
+        operator: params.opens_count_operator ?? "equal",
+        value: params.opens_count,
+      };
+    }
+    if (params.client_ip !== undefined) {
+      filters.client_ip = {
+        operator: params.client_ip_operator ?? "equal",
+        value: params.client_ip,
+      };
+    }
+    if (params.sending_ip !== undefined) {
+      filters.sending_ip = {
+        operator: params.sending_ip_operator ?? "equal",
+        value: params.sending_ip,
+      };
+    }
+    const espResponseVal = toValueArray(params.email_service_provider_response);
+    if (espResponseVal !== undefined) {
+      const op =
+        params.email_service_provider_response_operator ?? "ci_contain";
+      filters.email_service_provider_response = {
+        operator: op,
+        value: filterValue(espResponseVal, op),
+      };
+    }
+    const espVal = toValueArray(params.email_service_provider);
+    if (espVal !== undefined) {
+      const op = params.email_service_provider_operator ?? "equal";
+      filters.email_service_provider = {
+        operator: op,
+        value: filterValue(espVal, op),
+      };
+    }
+    const recipientMxVal = toValueArray(params.recipient_mx);
+    if (recipientMxVal !== undefined) {
+      const op = params.recipient_mx_operator ?? "ci_contain";
+      filters.recipient_mx = {
+        operator: op,
+        value: filterValue(recipientMxVal, op),
+      };
+    }
+    const categoryVal = toValueArray(params.category, true);
+    if (categoryVal !== undefined) {
+      const op = params.category_operator ?? "equal";
+      filters.category = {
+        operator: op,
+        value: filterValue(categoryVal, op),
+      };
+    }
+
+    const requestParams: { search_after?: string; filters?: Filters } = {};
+    if (params.search_after !== undefined)
+      requestParams.search_after = params.search_after;
+    if (Object.keys(filters).length > 0) requestParams.filters = filters;
+
+    const rawResponse = await client.emailLogs.getList(
+      Object.keys(requestParams).length > 0 ? requestParams : undefined
+    );
+    const responseParsed = listEmailLogsResponseZod.safeParse(rawResponse);
+    if (!responseParsed.success) {
+      const msg = responseParsed.error.errors
+        .map((e) => `${e.path.join(".")}: ${e.message}`)
+        .join("; ");
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Invalid list response from API: ${msg}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+    const response = responseParsed.data;
+    const list = response.messages ?? [];
+    const nextPageCursor = response.next_page_cursor ?? null;
+
+    if (list.length === 0) {
+      const noLogsText = nextPageCursor
+        ? `No email log messages found. Use search_after: "${nextPageCursor}" for pagination.`
+        : "No email log messages found.";
+      return {
+        content: [
+          {
+            type: "text",
+            text: noLogsText,
+          },
+        ],
+      };
+    }
+
+    const messageList = list
+      .map((entry: Record<string, unknown>) => {
+        const id = entry.message_id ?? entry.id ?? "—";
+        const summaryLines = buildMessageSummaryLines(
+          entry as EmailLogMessageDetails
+        );
+        return `• Message ID: ${id}\n  ${summaryLines.join("\n  ")}\n`;
+      })
+      .join("\n");
+
+    let text = `Found ${list.length} email log message(s):\n\n${messageList}`;
+    if (nextPageCursor) {
+      text += `\nNext page: use search_after: "${nextPageCursor}" to fetch more.`;
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text,
+        },
+      ],
+    };
+  } catch (error) {
+    console.error("Error listing email log messages:", error);
+
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to list email log messages: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default listEmailLogs;

--- a/src/tools/emailLogs/schemas/getEmailLogMessage.ts
+++ b/src/tools/emailLogs/schemas/getEmailLogMessage.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+const getEmailLogMessageSchema = {
+  type: "object",
+  properties: {
+    message_id: {
+      type: "string",
+      description:
+        "UUID of the email log message (from send response or list-email-logs)",
+    },
+    include_content: {
+      type: "boolean",
+      description:
+        "When true, download the raw EML message (if available) and include parsed HTML and text body content, similar to show-sandbox-email-message.",
+      default: false,
+    },
+  },
+  required: ["message_id"],
+  additionalProperties: false,
+};
+
+export const getEmailLogMessageZod = z
+  .object({
+    message_id: z.string().min(1, "message_id is required"),
+    include_content: z.boolean().optional().default(false),
+  })
+  .strict();
+
+export default getEmailLogMessageSchema;

--- a/src/tools/emailLogs/schemas/listEmailLogs.ts
+++ b/src/tools/emailLogs/schemas/listEmailLogs.ts
@@ -1,0 +1,386 @@
+import { z } from "zod";
+
+const stringOrStringArray = z.union([z.string(), z.array(z.string())]);
+
+const listEmailLogsSchema = {
+  type: "object",
+  properties: {
+    search_after: {
+      type: "string",
+      description:
+        "Pagination cursor from the previous response's next_page_cursor to fetch the next page",
+    },
+    sent_after: {
+      type: "string",
+      description:
+        "ISO 8601 date/time; only return logs for emails sent after this time",
+    },
+    sent_before: {
+      type: "string",
+      description:
+        "ISO 8601 date/time; only return logs for emails sent before this time",
+    },
+    from_email: {
+      oneOf: [
+        { type: "string", description: "Single sender email" },
+        {
+          type: "array",
+          items: { type: "string" },
+          description: "Multiple sender emails (match any)",
+        },
+      ],
+      description:
+        "Filter by sender email (use with from_operator). Single value or array.",
+    },
+    from_operator: {
+      type: "string",
+      enum: ["ci_contain", "ci_not_contain", "ci_equal", "ci_not_equal"],
+      description:
+        "Operator for from_email filter. Default: ci_equal. ci_contain/ci_not_contain match substring; ci_equal/ci_not_equal match exactly (case-insensitive).",
+    },
+    to_email: {
+      oneOf: [
+        { type: "string", description: "Single recipient email" },
+        {
+          type: "array",
+          items: { type: "string" },
+          description: "Multiple recipient emails (match any)",
+        },
+      ],
+      description:
+        "Filter by recipient email (use with to_operator). Single value or array.",
+    },
+    to_operator: {
+      type: "string",
+      enum: ["ci_contain", "ci_not_contain", "ci_equal", "ci_not_equal"],
+      description: "Operator for to_email filter. Default: ci_equal.",
+    },
+    status: {
+      oneOf: [
+        {
+          type: "string",
+          enum: ["delivered", "not_delivered", "enqueued", "opted_out"],
+        },
+        {
+          type: "array",
+          items: {
+            type: "string",
+            enum: ["delivered", "not_delivered", "enqueued", "opted_out"],
+          },
+        },
+      ],
+      description:
+        "Filter by delivery status (use with status_operator). Single value or array.",
+    },
+    status_operator: {
+      type: "string",
+      enum: ["equal", "not_equal"],
+      description: "Operator for status filter. Default: equal.",
+    },
+    subject: {
+      oneOf: [
+        { type: "string", description: "Single subject pattern" },
+        {
+          type: "array",
+          items: { type: "string" },
+          description: "Multiple subject patterns (match any)",
+        },
+      ],
+      description:
+        "Filter by email subject (use with subject_operator). Single value or array. Omit for empty/not_empty.",
+    },
+    subject_operator: {
+      type: "string",
+      enum: [
+        "ci_contain",
+        "ci_not_contain",
+        "ci_equal",
+        "ci_not_equal",
+        "empty",
+        "not_empty",
+      ],
+      description:
+        "Operator for subject filter. Default: ci_contain. Use empty/not_empty to filter by presence of subject.",
+    },
+    sending_domain_id: {
+      oneOf: [
+        { type: "number", description: "Single sending domain ID" },
+        {
+          type: "array",
+          items: { type: "number" },
+          description: "Multiple sending domain IDs (match any)",
+        },
+      ],
+      description:
+        "Filter by sending domain ID. Single value or array. Find IDs in Mailtrap Sending Domains.",
+    },
+    sending_domain_id_operator: {
+      type: "string",
+      enum: ["equal", "not_equal"],
+      description: "Operator for sending_domain_id filter. Default: equal.",
+    },
+    sending_stream: {
+      oneOf: [
+        {
+          type: "string",
+          enum: ["transactional", "bulk"],
+        },
+        {
+          type: "array",
+          items: {
+            type: "string",
+            enum: ["transactional", "bulk"],
+          },
+        },
+      ],
+      description:
+        "Filter by sending stream: transactional or bulk. Single value or array.",
+    },
+    sending_stream_operator: {
+      type: "string",
+      enum: ["equal", "not_equal"],
+      description: "Operator for sending_stream filter. Default: equal.",
+    },
+    events: {
+      oneOf: [
+        {
+          type: "string",
+          enum: [
+            "delivery",
+            "open",
+            "click",
+            "bounce",
+            "spam",
+            "unsubscribe",
+            "soft_bounce",
+            "reject",
+            "suspension",
+          ],
+        },
+        {
+          type: "array",
+          items: {
+            type: "string",
+            enum: [
+              "delivery",
+              "open",
+              "click",
+              "bounce",
+              "spam",
+              "unsubscribe",
+              "soft_bounce",
+              "reject",
+              "suspension",
+            ],
+          },
+        },
+      ],
+      description:
+        "Filter by event type(s). Use with events_operator: include_event or not_include_event.",
+    },
+    events_operator: {
+      type: "string",
+      enum: ["include_event", "not_include_event"],
+      description: "Operator for events filter. Default: include_event.",
+    },
+    clicks_count: {
+      type: "number",
+      description:
+        "Filter by number of link clicks. Use with clicks_count_operator.",
+    },
+    clicks_count_operator: {
+      type: "string",
+      enum: ["equal", "greater_than", "less_than"],
+      description: "Operator for clicks_count. Default: equal.",
+    },
+    opens_count: {
+      type: "number",
+      description: "Filter by number of opens. Use with opens_count_operator.",
+    },
+    opens_count_operator: {
+      type: "string",
+      enum: ["equal", "greater_than", "less_than"],
+      description: "Operator for opens_count. Default: equal.",
+    },
+    client_ip: {
+      type: "string",
+      description: "Filter by client IP. Use with client_ip_operator.",
+    },
+    client_ip_operator: {
+      type: "string",
+      enum: ["equal", "not_equal", "contain", "not_contain"],
+      description: "Operator for client_ip. Default: equal.",
+    },
+    sending_ip: {
+      type: "string",
+      description: "Filter by sending IP. Use with sending_ip_operator.",
+    },
+    sending_ip_operator: {
+      type: "string",
+      enum: ["equal", "not_equal", "contain", "not_contain"],
+      description: "Operator for sending_ip. Default: equal.",
+    },
+    email_service_provider_response: {
+      oneOf: [{ type: "string" }, { type: "array", items: { type: "string" } }],
+      description:
+        "Filter by provider response text. Single value or array. Use with *_operator.",
+    },
+    email_service_provider_response_operator: {
+      type: "string",
+      enum: ["ci_contain", "ci_not_contain", "ci_equal", "ci_not_equal"],
+      description:
+        "Operator for email_service_provider_response. Default: ci_contain.",
+    },
+    email_service_provider: {
+      oneOf: [{ type: "string" }, { type: "array", items: { type: "string" } }],
+      description:
+        "Filter by email service provider (exact). Single value or array. Use with *_operator.",
+    },
+    email_service_provider_operator: {
+      type: "string",
+      enum: ["equal", "not_equal"],
+      description: "Operator for email_service_provider. Default: equal.",
+    },
+    recipient_mx: {
+      oneOf: [{ type: "string" }, { type: "array", items: { type: "string" } }],
+      description:
+        "Filter by recipient MX. Single value or array. Use with recipient_mx_operator.",
+    },
+    recipient_mx_operator: {
+      type: "string",
+      enum: ["ci_contain", "ci_not_contain", "ci_equal", "ci_not_equal"],
+      description: "Operator for recipient_mx. Default: ci_contain.",
+    },
+    category: {
+      oneOf: [
+        { type: "string", description: "Single category value." },
+        {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Multiple category values (OR). Logs matching any value are returned.",
+        },
+      ],
+      description:
+        'Filter by email category. Use with category_operator. Single value, array (e.g. ["Newsletter", "Alert"]), or comma-separated string (e.g. "Newsletter,Alert") for multiple (OR).',
+    },
+    category_operator: {
+      type: "string",
+      enum: ["equal", "not_equal"],
+      description: "Operator for category. Default: equal.",
+    },
+  },
+  required: [],
+  additionalProperties: false,
+};
+
+export const listEmailLogsZod = z
+  .object({
+    search_after: z.string().optional(),
+    sent_after: z.string().optional(),
+    sent_before: z.string().optional(),
+    from_email: stringOrStringArray.optional(),
+    from_operator: z
+      .enum(["ci_contain", "ci_not_contain", "ci_equal", "ci_not_equal"])
+      .optional(),
+    to_email: stringOrStringArray.optional(),
+    to_operator: z
+      .enum(["ci_contain", "ci_not_contain", "ci_equal", "ci_not_equal"])
+      .optional(),
+    status: z
+      .union([
+        z.enum(["delivered", "not_delivered", "enqueued", "opted_out"]),
+        z.array(
+          z.enum(["delivered", "not_delivered", "enqueued", "opted_out"])
+        ),
+      ])
+      .optional(),
+    status_operator: z.enum(["equal", "not_equal"]).optional(),
+    subject: stringOrStringArray.optional(),
+    subject_operator: z
+      .enum([
+        "ci_contain",
+        "ci_not_contain",
+        "ci_equal",
+        "ci_not_equal",
+        "empty",
+        "not_empty",
+      ])
+      .optional(),
+    sending_domain_id: z.union([z.number(), z.array(z.number())]).optional(),
+    sending_domain_id_operator: z.enum(["equal", "not_equal"]).optional(),
+    sending_stream: z
+      .union([
+        z.enum(["transactional", "bulk"]),
+        z.array(z.enum(["transactional", "bulk"])),
+      ])
+      .optional(),
+    sending_stream_operator: z.enum(["equal", "not_equal"]).optional(),
+    events: z
+      .union([
+        z.enum([
+          "delivery",
+          "open",
+          "click",
+          "bounce",
+          "spam",
+          "unsubscribe",
+          "soft_bounce",
+          "reject",
+          "suspension",
+        ]),
+        z.array(
+          z.enum([
+            "delivery",
+            "open",
+            "click",
+            "bounce",
+            "spam",
+            "unsubscribe",
+            "soft_bounce",
+            "reject",
+            "suspension",
+          ])
+        ),
+      ])
+      .optional(),
+    events_operator: z.enum(["include_event", "not_include_event"]).optional(),
+    clicks_count: z.number().optional(),
+    clicks_count_operator: z
+      .enum(["equal", "greater_than", "less_than"])
+      .optional(),
+    opens_count: z.number().optional(),
+    opens_count_operator: z
+      .enum(["equal", "greater_than", "less_than"])
+      .optional(),
+    client_ip: z.string().optional(),
+    client_ip_operator: z
+      .enum(["equal", "not_equal", "contain", "not_contain"])
+      .optional(),
+    sending_ip: z.string().optional(),
+    sending_ip_operator: z
+      .enum(["equal", "not_equal", "contain", "not_contain"])
+      .optional(),
+    email_service_provider_response: stringOrStringArray.optional(),
+    email_service_provider_response_operator: z
+      .enum(["ci_contain", "ci_not_contain", "ci_equal", "ci_not_equal"])
+      .optional(),
+    email_service_provider: stringOrStringArray.optional(),
+    email_service_provider_operator: z.enum(["equal", "not_equal"]).optional(),
+    recipient_mx: stringOrStringArray.optional(),
+    recipient_mx_operator: z
+      .enum(["ci_contain", "ci_not_contain", "ci_equal", "ci_not_equal"])
+      .optional(),
+    category: stringOrStringArray.optional(),
+    category_operator: z.enum(["equal", "not_equal"]).optional(),
+  })
+  .strict();
+
+/** Runtime validation for client.emailLogs.getList() response. */
+export const listEmailLogsResponseZod = z.object({
+  messages: z.array(z.record(z.unknown())).optional(),
+  total_count: z.number().optional(),
+  next_page_cursor: z.string().nullable().optional(),
+});
+
+export default listEmailLogsSchema;

--- a/src/tools/emailLogs/utils/emailLogEventFormat.ts
+++ b/src/tools/emailLogs/utils/emailLogEventFormat.ts
@@ -1,0 +1,71 @@
+/** Formats `EmailLogMessageEvent` detail fields (mailtrap SDK) for display. */
+export type LogEventDetails = Record<string, unknown>;
+
+export function isMailtrapEmailLogEvent(
+  e: unknown
+): e is { event_type: string; created_at: string; details?: LogEventDetails } {
+  return (
+    typeof e === "object" &&
+    e !== null &&
+    typeof (e as { event_type?: unknown }).event_type === "string" &&
+    typeof (e as { created_at?: unknown }).created_at === "string"
+  );
+}
+
+export function formatEventDetailLines(
+  details: LogEventDetails | undefined,
+  eventType: string
+): string[] {
+  if (!details || typeof details !== "object") return [];
+  const out: string[] = [];
+  const add = (label: string, v: unknown) => {
+    if (v != null && String(v) !== "") {
+      out.push(`    ${label}: ${v}`);
+    }
+  };
+  switch (eventType) {
+    case "delivery":
+      add("Sending IP", details.sending_ip);
+      add("Recipient mail server (MX)", details.recipient_mx);
+      add("Mailbox provider", details.email_service_provider);
+      break;
+    case "open":
+      add("Client IP", details.web_ip_address);
+      break;
+    case "click":
+      add("Clicked URL", details.click_url);
+      add("Client IP", details.web_ip_address);
+      break;
+    case "bounce":
+    case "soft_bounce":
+      add("Sending IP", details.sending_ip);
+      add("Recipient mail server (MX)", details.recipient_mx);
+      add("Mailbox provider", details.email_service_provider);
+      add("Provider status code", details.email_service_provider_status);
+      add("Provider response", details.email_service_provider_response);
+      add("Bounce category", details.bounce_category);
+      break;
+    case "spam":
+      add("Spam feedback type", details.spam_feedback_type);
+      break;
+    case "unsubscribe":
+      add("Client IP", details.web_ip_address);
+      break;
+    case "reject":
+    case "suspension":
+      add("Reject reason", details.reject_reason);
+      break;
+    default:
+      break;
+  }
+  return out;
+}
+
+export function formatEmailLogEvent(event: unknown): string {
+  if (!isMailtrapEmailLogEvent(event)) {
+    return `  • (unrecognized event): ${JSON.stringify(event)}`;
+  }
+  const lines = [`  • ${event.event_type}: ${event.created_at}`];
+  lines.push(...formatEventDetailLines(event.details, event.event_type));
+  return lines.join("\n");
+}

--- a/src/tools/emailLogs/utils/emailLogMessageSummary.ts
+++ b/src/tools/emailLogs/utils/emailLogMessageSummary.ts
@@ -1,0 +1,56 @@
+import type { EmailLogMessageDetails } from "../../../types/mailtrap";
+import { isMailtrapEmailLogEvent } from "./emailLogEventFormat";
+
+export function disp(v: unknown): string {
+  if (v === null || v === undefined || v === "") return "—";
+  return String(v);
+}
+
+/** Readable overview of the message (headers, engagement, delivery context). */
+export function buildMessageSummaryLines(
+  entry: EmailLogMessageDetails
+): string[] {
+  const events = entry.events ?? [];
+  const evs = events.filter(isMailtrapEmailLogEvent);
+  const delivery = evs.find((e) => e.event_type === "delivery");
+  const bounce = evs.find(
+    (e) => e.event_type === "bounce" || e.event_type === "soft_bounce"
+  );
+  const deliveryD =
+    delivery?.event_type === "delivery" ? delivery.details : undefined;
+  const bounceD =
+    bounce?.event_type === "bounce" || bounce?.event_type === "soft_bounce"
+      ? bounce.details
+      : undefined;
+  const sendingIp = deliveryD?.sending_ip ?? bounceD?.sending_ip ?? null;
+  const recipientMx = deliveryD?.recipient_mx ?? bounceD?.recipient_mx ?? null;
+  const esp =
+    deliveryD?.email_service_provider ??
+    bounceD?.email_service_provider ??
+    null;
+  const espResponse = bounceD?.email_service_provider_response ?? null;
+
+  const eventsLabel = evs.length
+    ? evs.map((e) => e.event_type).join(", ")
+    : "—";
+
+  return [
+    `From: ${disp(entry.from)}`,
+    `To: ${disp(entry.to)}`,
+    `Subject: ${disp(entry.subject)}`,
+    `Sent: ${disp(entry.sent_at)}`,
+    `Status: ${disp(entry.status)}`,
+    `Category: ${disp(entry.category)}`,
+    `Stream: ${disp(entry.sending_stream)}`,
+    `Sending domain ID: ${disp(entry.sending_domain_id)}`,
+    `Opens: ${disp(entry.opens_count)} · Link clicks: ${disp(
+      entry.clicks_count
+    )}`,
+    `Client IP: ${disp(entry.client_ip)}`,
+    `Events recorded: ${eventsLabel}`,
+    `Sending IP: ${disp(sendingIp)}`,
+    `Recipient mail server (MX): ${disp(recipientMx)}`,
+    `Mailbox provider: ${disp(esp)}`,
+    `Bounce / provider response: ${disp(espResponse)}`,
+  ];
+}

--- a/src/tools/emailLogs/utils/parseEmlBuffer.ts
+++ b/src/tools/emailLogs/utils/parseEmlBuffer.ts
@@ -1,0 +1,68 @@
+import { Readable } from "stream";
+import { Splitter, SplitterData } from "mailsplit";
+
+async function parseEmlBuffer(emlBuffer: Buffer): Promise<{
+  htmlContent: string;
+  textContent: string;
+}> {
+  let htmlContent = "";
+  let textContent = "";
+  let currentDecoder: NodeJS.ReadWriteStream | null = null;
+  let currentType: "text/html" | "text/plain" | null = null;
+  let splitterEnded = false;
+  let pendingDecoders = 0;
+  let resolveDone: () => void = () => {};
+  let rejectDone: (err: Error) => void = () => {};
+
+  const done = new Promise<void>((resolve, reject) => {
+    resolveDone = resolve;
+    rejectDone = reject;
+  });
+
+  const splitter = new Splitter();
+  splitter.on("error", (err: Error) => rejectDone(err));
+  splitter.on("data", (data: SplitterData) => {
+    if (data.type === "node") {
+      if (currentDecoder) {
+        currentDecoder.end();
+      }
+      if (
+        data.contentType === "text/html" ||
+        data.contentType === "text/plain"
+      ) {
+        currentDecoder = data.getDecoder?.() ?? null;
+        currentType = data.contentType as "text/html" | "text/plain";
+        if (currentDecoder) {
+          const partType = currentType;
+          pendingDecoders += 1;
+          const chunks: Buffer[] = [];
+          currentDecoder.on("error", (err: Error) => rejectDone(err));
+          currentDecoder.on("data", (c: Buffer) => chunks.push(c));
+          currentDecoder.on("end", () => {
+            const s = Buffer.concat(chunks).toString("utf8");
+            if (partType === "text/html") htmlContent = s;
+            else textContent = s;
+            pendingDecoders -= 1;
+            if (pendingDecoders === 0 && splitterEnded) resolveDone();
+          });
+        }
+      } else {
+        currentDecoder = null;
+      }
+    } else if (data.type === "body" && currentDecoder && data.value) {
+      currentDecoder.write(data.value);
+    }
+  });
+  splitter.on("end", () => {
+    splitterEnded = true;
+    if (currentDecoder) currentDecoder.end();
+    if (pendingDecoders === 0) resolveDone();
+  });
+
+  const readable = Readable.from([emlBuffer]);
+  readable.pipe(splitter);
+  await done;
+  return { htmlContent, textContent };
+}
+
+export default parseEmlBuffer;

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -65,3 +65,129 @@ export interface GetMessagesRequest {
 export interface ShowEmailMessageRequest {
   message_id: number;
 }
+
+/** From/to filter operators (case-insensitive). */
+export type EmailLogFromToOperator =
+  | "ci_contain"
+  | "ci_not_contain"
+  | "ci_equal"
+  | "ci_not_equal";
+
+/** Status filter operators. */
+export type EmailLogStatusOperator = "equal" | "not_equal";
+
+/** Valid status values for email log filters (Mailtrap API). */
+export type EmailLogMessageStatus =
+  | "delivered"
+  | "not_delivered"
+  | "enqueued"
+  | "opted_out";
+
+/** Subject filter operators (FilterSubject in SDK). */
+export type EmailLogSubjectOperator =
+  | "ci_contain"
+  | "ci_not_contain"
+  | "ci_equal"
+  | "ci_not_equal"
+  | "empty"
+  | "not_empty";
+
+/** Sending stream values (Mailtrap API). */
+export type EmailLogSendingStream = "transactional" | "bulk";
+
+/** Event types for events filter (Mailtrap API). */
+export type EmailLogEventType =
+  | "delivery"
+  | "open"
+  | "click"
+  | "bounce"
+  | "spam"
+  | "unsubscribe"
+  | "soft_bounce"
+  | "reject"
+  | "suspension";
+
+/** Number filter operators (clicks_count, opens_count). */
+export type EmailLogNumberOperator = "equal" | "greater_than" | "less_than";
+
+/** IP filter operators (client_ip, sending_ip). */
+export type EmailLogIpOperator =
+  | "equal"
+  | "not_equal"
+  | "contain"
+  | "not_contain";
+
+/** Events filter operators. */
+export type EmailLogEventsOperator = "include_event" | "not_include_event";
+
+export interface ListEmailLogsRequest {
+  search_after?: string;
+  sent_after?: string;
+  sent_before?: string;
+  from_email?: string | string[];
+  from_operator?: EmailLogFromToOperator;
+  to_email?: string | string[];
+  to_operator?: EmailLogFromToOperator;
+  status?: EmailLogMessageStatus | EmailLogMessageStatus[];
+  status_operator?: EmailLogStatusOperator;
+  subject?: string | string[];
+  subject_operator?: EmailLogSubjectOperator;
+  sending_domain_id?: number | number[];
+  sending_domain_id_operator?: "equal" | "not_equal";
+  sending_stream?: EmailLogSendingStream | EmailLogSendingStream[];
+  sending_stream_operator?: "equal" | "not_equal";
+  events?: EmailLogEventType | EmailLogEventType[];
+  events_operator?: EmailLogEventsOperator;
+  clicks_count?: number;
+  clicks_count_operator?: EmailLogNumberOperator;
+  opens_count?: number;
+  opens_count_operator?: EmailLogNumberOperator;
+  client_ip?: string;
+  client_ip_operator?: EmailLogIpOperator;
+  sending_ip?: string;
+  sending_ip_operator?: EmailLogIpOperator;
+  email_service_provider_response?: string | string[];
+  email_service_provider_response_operator?: EmailLogFromToOperator;
+  email_service_provider?: string | string[];
+  email_service_provider_operator?: "equal" | "not_equal";
+  recipient_mx?: string | string[];
+  recipient_mx_operator?: EmailLogFromToOperator;
+  category?: string | string[];
+  category_operator?: "equal" | "not_equal";
+}
+
+export interface GetEmailLogMessageRequest {
+  message_id: string;
+  /** When true, fetch raw EML from raw_message_url (if present) and include parsed HTML and text body. */
+  include_content?: boolean;
+}
+
+/**
+ * Shape of a single email log row from client.emailLogs.get() (mailtrap SDK).
+ * Defined locally to avoid depending on SDK internals (mailtrap/dist/types/api/email-logs).
+ * If the SDK response shape changes, reconcile fields here and in buildMessageSummaryLines / getEmailLogMessage.
+ */
+export interface EmailLogMessageDetails {
+  message_id?: string;
+  status?: string;
+  from?: string;
+  to?: string;
+  subject?: string;
+  sent_at?: string;
+  client_ip?: string;
+  category?: string;
+  custom_variables?: Record<string, unknown>;
+  sending_domain_id?: number;
+  sending_stream?: string;
+  template_id?: number | null;
+  template_variables?: Record<string, unknown>;
+  opens_count?: number;
+  clicks_count?: number;
+  events?: Array<{
+    event_type: string;
+    created_at: string;
+    details?: Record<string, unknown>;
+  }>;
+  raw_message_url?: string;
+  error?: string;
+}


### PR DESCRIPTION
## Changes

- Bump mailtrap to 4.5.1
- Add email-logs tools
  - Listing email logs with filters
  - Getting the details of specific message with its html/text content
- Fix formatting in md files

## Images and GIFs

<img width="741" height="905" alt="Screenshot 2026-03-18 at 17 36 52" src="https://github.com/user-attachments/assets/7b9017f4-676c-4071-af67-f78fe097adbd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email log listing with filters, pagination and delivery details.
  * Email log retrieval for individual messages with optional raw message content parsing.
  * Expanded sending statistics with richer breakdown and filtering.

* **Documentation**
  * Updated README/CHANGELOG/tool docs and environment-variable guidance to reflect new tools and usage.

* **Tests**
  * Added comprehensive tests for listing, retrieval, parsing, event formatting, and summary generation.

* **Chores**
  * Bumped dependencies and added type declarations to support email parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->