### PR TITLE
Add sending-domains tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add **list-email-logs** and **get-email-log-message** tools: query sent-mail delivery history with filters and pagination; inspect a single log by UUID (summary, event timeline, optional body via `include_content`).
 * Add **get-sending-stats** tool: check delivery, bounce, open, click, and spam rates for a date range; optional breakdown by domain, category, email service provider, or date.
+* Add **sending domains** tools: **list-sending-domains**, **get-sending-domain**, **create-sending-domain**, **delete-sending-domain**. **get-sending-domain** accepts optional `include_setup_instructions: true` to append DNS setup instructions to the response.
 
 ## [0.1.0] - 2025-12-09
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Schema files define a JSON Schema–shaped object for MCP; optional Zod schemas 
 
 - `MAILTRAP_API_TOKEN`: Required API token from Mailtrap
 - `DEFAULT_FROM_EMAIL`: Default sender email address
-- `MAILTRAP_ACCOUNT_ID`: Required for almost all tools (templates, stats, email logs, sandbox list/show). Optional only for send-email and send-sandbox-email.
+- `MAILTRAP_ACCOUNT_ID`: Required for templates, stats, email logs, sandbox list/show, and sending domains. Optional only for send-email and send-sandbox-email.
 - `MAILTRAP_TEST_INBOX_ID`: Required for sandbox tools - test inbox ID for sandbox mode operations
 
 ### Testing Setup
@@ -95,5 +95,13 @@ Schema files define a JSON Schema–shaped object for MCP; optional Zod schemas 
 - **send-sandbox-email**: Send email in sandbox mode to a test inbox.
 - **get-sandbox-messages**: Get list of messages from the sandbox test inbox.
 - **show-sandbox-email-message**: Show sandbox email message details and content from the sandbox test inbox.
+
+
+#### Sending Domains
+
+- **list-sending-domains**: List sending domains and their DNS verification status.
+- **get-sending-domain**: Get a sending domain by ID and its verification status. With `include_setup_instructions: true`, append DNS setup instructions to the response.
+- **create-sending-domain**: Create a new sending domain.
+- **delete-sending-domain**: Delete a sending domain.
 
 Tools use input schemas (JSON Schema format) for MCP; handlers may validate input with Zod. Response format follows the MCP protocol.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Before using this MCP server, you need to:
 
 - `MAILTRAP_API_TOKEN` - Required for all functionality
 - `DEFAULT_FROM_EMAIL` - Required for all email sending operations
-- `MAILTRAP_ACCOUNT_ID` - Required for almost all tools (templates, stats, email logs, sandbox list/show). Optional only for send-email and send-sandbox-email.
+- `MAILTRAP_ACCOUNT_ID` - Required for templates, stats, email logs, sandbox list/show, and sending domains. Optional only for send-email and send-sandbox-email.
 - `MAILTRAP_TEST_INBOX_ID` - Required for sandbox tools (send, list messages, show message)
 
 ## Quick Install
@@ -188,6 +188,14 @@ Once configured, you can ask agent to send emails and manage templates, for exam
 - "Update the template with ID 12345 to change the subject to 'Updated Welcome Message'"
 - "Delete the template with ID 67890"
 
+**Sending Domains:**
+
+- "List my sending domains"
+- "Get sending domain with ID 3938"
+- "Create a sending domain for example.com"
+- "Delete sending domain 3938"
+- "Get sending domain 3938 with DNS setup instructions"
+
 ## Available Tools
 
 ### send-email
@@ -339,6 +347,39 @@ Shows detailed information and content of a specific email message from your Mai
 > [!NOTE]
 > Use `get-sandbox-messages` first to get the list of messages and their IDs, then use this tool to view the full content of a specific message.
 
+
+### list-sending-domains
+
+List sending domains and their DNS verification status.
+
+**Parameters:**
+
+- No parameters required
+
+### get-sending-domain
+
+Get a sending domain by ID and its verification status (including DNS records). Optionally include DNS setup instructions by setting `include_setup_instructions` to `true`.
+
+**Parameters:**
+
+- `sending_domain_id` (required): Sending domain ID
+- `include_setup_instructions` (optional): If `true`, append DNS setup instructions to the response. Default: `false`
+
+### create-sending-domain
+
+Create a new sending domain. After creation, add DNS records to verify the domain (use get-sending-domain with `include_setup_instructions: true` to see the records).
+
+**Parameters:**
+
+- `domain_name` (required): Domain name (e.g. example.com)
+
+### delete-sending-domain
+
+Delete a sending domain.
+
+**Parameters:**
+
+- `sending_domain_id` (required): Sending domain ID to delete
 
 ## Development
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,6 +37,16 @@ import {
   getEmailLogMessage,
   getEmailLogMessageSchema,
 } from "./tools/emailLogs";
+import {
+  listSendingDomains,
+  listSendingDomainsSchema,
+  getSendingDomain,
+  getSendingDomainSchema,
+  createSendingDomain,
+  createSendingDomainSchema,
+  deleteSendingDomain,
+  deleteSendingDomainSchema,
+} from "./tools/sendingDomains";
 
 // Define the tools registry
 const tools = [
@@ -137,6 +147,43 @@ const tools = [
     handler: getEmailLogMessage,
     annotations: {
       readOnlyHint: true,
+    },
+  },
+  {
+    name: "list-sending-domains",
+    description: "List sending domains and their DNS verification status",
+    inputSchema: listSendingDomainsSchema,
+    handler: listSendingDomains,
+    annotations: {
+      readOnlyHint: true,
+    },
+  },
+  {
+    name: "get-sending-domain",
+    description:
+      "Get a sending domain by ID and its verification status. Optionally include DNS setup instructions via include_setup_instructions.",
+    inputSchema: getSendingDomainSchema,
+    handler: getSendingDomain,
+    annotations: {
+      readOnlyHint: true,
+    },
+  },
+  {
+    name: "create-sending-domain",
+    description: "Create a new sending domain",
+    inputSchema: createSendingDomainSchema,
+    handler: createSendingDomain,
+    annotations: {
+      destructiveHint: true,
+    },
+  },
+  {
+    name: "delete-sending-domain",
+    description: "Delete a sending domain",
+    inputSchema: deleteSendingDomainSchema,
+    handler: deleteSendingDomain,
+    annotations: {
+      destructiveHint: true,
     },
   },
 ];

--- a/src/tools/sendingDomains/__tests__/createSendingDomain.test.ts
+++ b/src/tools/sendingDomains/__tests__/createSendingDomain.test.ts
@@ -1,0 +1,73 @@
+import createSendingDomain from "../createSendingDomain";
+import { client } from "../../../client";
+
+jest.mock("../../../client", () => ({
+  client: {
+    sendingDomains: {
+      create: jest.fn(),
+    },
+  },
+}));
+
+const originalEnv = { ...process.env };
+
+describe("createSendingDomain", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.assign(process.env, { MAILTRAP_ACCOUNT_ID: "12345" });
+    (client.sendingDomains.create as jest.Mock).mockResolvedValue({
+      id: 3938,
+      domain_name: "example.com",
+      dns_records: [
+        {
+          key: "verification",
+          type: "CNAME",
+          name: "verify123",
+          value: "smtp.mailtrap.live",
+          status: "pending",
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, originalEnv);
+  });
+
+  it("should create sending domain successfully and show DNS setup instructions", async () => {
+    const result = await createSendingDomain({ domain_name: "example.com" });
+
+    expect(client.sendingDomains.create).toHaveBeenCalledWith({
+      domain_name: "example.com",
+    });
+    expect(result.content[0].text).toContain("example.com");
+    expect(result.content[0].text).toContain("created successfully");
+    expect(result.content[0].text).toContain("3938");
+    expect(result.content[0].text).toContain("Add DNS records for example.com");
+    expect(result.content[0].text).toContain("DNS records to add:");
+    expect(result.content[0].text).toContain("verification");
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("should require MAILTRAP_ACCOUNT_ID", async () => {
+    delete process.env.MAILTRAP_ACCOUNT_ID;
+
+    const result = await createSendingDomain({ domain_name: "example.com" });
+
+    expect(client.sendingDomains.create).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+  });
+
+  it("should handle API failure", async () => {
+    (client.sendingDomains.create as jest.Mock).mockRejectedValue(
+      new Error("Domain already exists")
+    );
+
+    const result = await createSendingDomain({ domain_name: "example.com" });
+
+    expect(result.content[0].text).toEqual(
+      "Failed to create sending domain: Domain already exists"
+    );
+    expect(result.isError).toBe(true);
+  });
+});

--- a/src/tools/sendingDomains/__tests__/deleteSendingDomain.test.ts
+++ b/src/tools/sendingDomains/__tests__/deleteSendingDomain.test.ts
@@ -1,0 +1,53 @@
+import deleteSendingDomain from "../deleteSendingDomain";
+import { client } from "../../../client";
+
+jest.mock("../../../client", () => ({
+  client: {
+    sendingDomains: {
+      delete: jest.fn(),
+    },
+  },
+}));
+
+const originalEnv = { ...process.env };
+
+describe("deleteSendingDomain", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.assign(process.env, { MAILTRAP_ACCOUNT_ID: "12345" });
+    (client.sendingDomains.delete as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, originalEnv);
+  });
+
+  it("should delete sending domain successfully", async () => {
+    const result = await deleteSendingDomain({ sending_domain_id: 3938 });
+
+    expect(client.sendingDomains.delete).toHaveBeenCalledWith(3938);
+    expect(result.content[0].text).toContain("deleted successfully");
+    expect(result.content[0].text).toContain("3938");
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("should require MAILTRAP_ACCOUNT_ID", async () => {
+    delete process.env.MAILTRAP_ACCOUNT_ID;
+
+    const result = await deleteSendingDomain({ sending_domain_id: 3938 });
+
+    expect(client.sendingDomains.delete).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+  });
+
+  it("should handle API failure", async () => {
+    (client.sendingDomains.delete as jest.Mock).mockRejectedValue(
+      new Error("Not found")
+    );
+
+    const result = await deleteSendingDomain({ sending_domain_id: 999 });
+
+    expect(result.content[0].text).toContain("Failed to delete sending domain");
+    expect(result.isError).toBe(true);
+  });
+});

--- a/src/tools/sendingDomains/__tests__/getSendingDomain.test.ts
+++ b/src/tools/sendingDomains/__tests__/getSendingDomain.test.ts
@@ -1,0 +1,101 @@
+import getSendingDomain from "../getSendingDomain";
+import { client } from "../../../client";
+
+jest.mock("../../../client", () => ({
+  client: {
+    sendingDomains: {
+      get: jest.fn(),
+    },
+  },
+}));
+
+const originalEnv = { ...process.env };
+
+describe("getSendingDomain", () => {
+  const mockDomain = {
+    id: 3938,
+    domain_name: "example.com",
+    demo: false,
+    compliance_status: "compliant",
+    dns_verified: true,
+    dns_verified_at: "2024-12-26T09:40:44.161Z",
+    dns_records: [
+      {
+        key: "spf",
+        type: "TXT",
+        name: "",
+        value: "v=spf1 include:_spf.smtp.mailtrap.live ~all",
+        status: "pass",
+        domain: "example.com",
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.assign(process.env, { MAILTRAP_ACCOUNT_ID: "12345" });
+    (client.sendingDomains.get as jest.Mock).mockResolvedValue(mockDomain);
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, originalEnv);
+  });
+
+  it("should get sending domain successfully", async () => {
+    const result = await getSendingDomain({ sending_domain_id: 3938 });
+
+    expect(client.sendingDomains.get).toHaveBeenCalledWith(3938);
+    expect(result.content[0].text).toContain("example.com");
+    expect(result.content[0].text).toContain("ID: 3938");
+    expect(result.content[0].text).toContain("DNS verified: true");
+    expect(result.content[0].text).toContain("spf");
+    expect(result.content[0].text).toContain("pass");
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("should include setup instructions when include_setup_instructions is true", async () => {
+    const result = await getSendingDomain({
+      sending_domain_id: 3938,
+      include_setup_instructions: true,
+    });
+
+    expect(client.sendingDomains.get).toHaveBeenCalledWith(3938);
+    expect(result.content[0].text).toContain("Domain: example.com");
+    expect(result.content[0].text).toContain("Add DNS records for example.com");
+    expect(result.content[0].text).toContain("What?");
+    expect(result.content[0].text).toContain("Why?");
+    expect(result.content[0].text).toContain("DNS records to add");
+    expect(result.content[0].text).toContain("docs.mailtrap.io");
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("should not include setup instructions when include_setup_instructions is false or omitted", async () => {
+    const result = await getSendingDomain({
+      sending_domain_id: 3938,
+      include_setup_instructions: false,
+    });
+
+    expect(result.content[0].text).not.toContain("Add DNS records for");
+    expect(result.content[0].text).not.toContain("What?");
+  });
+
+  it("should require MAILTRAP_ACCOUNT_ID", async () => {
+    delete process.env.MAILTRAP_ACCOUNT_ID;
+
+    const result = await getSendingDomain({ sending_domain_id: 3938 });
+
+    expect(client.sendingDomains.get).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+  });
+
+  it("should handle API failure", async () => {
+    (client.sendingDomains.get as jest.Mock).mockRejectedValue(
+      new Error("Not found")
+    );
+
+    const result = await getSendingDomain({ sending_domain_id: 999 });
+
+    expect(result.content[0].text).toContain("Failed to get sending domain");
+    expect(result.isError).toBe(true);
+  });
+});

--- a/src/tools/sendingDomains/__tests__/listSendingDomains.test.ts
+++ b/src/tools/sendingDomains/__tests__/listSendingDomains.test.ts
@@ -1,0 +1,88 @@
+import listSendingDomains from "../listSendingDomains";
+import { client } from "../../../client";
+
+jest.mock("../../../client", () => ({
+  client: {
+    sendingDomains: {
+      getList: jest.fn(),
+    },
+  },
+}));
+
+const originalEnv = { ...process.env };
+
+describe("listSendingDomains", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.assign(process.env, { MAILTRAP_ACCOUNT_ID: "12345" });
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, originalEnv);
+  });
+
+  it("should list sending domains successfully", async () => {
+    const mockDomains = {
+      data: [
+        {
+          id: 1,
+          domain_name: "example.com",
+          dns_verified: true,
+          compliance_status: "compliant",
+        },
+        {
+          id: 2,
+          domain_name: "test.com",
+          dns_verified: false,
+          compliance_status: "pending",
+        },
+      ],
+    };
+    (client.sendingDomains.getList as jest.Mock).mockResolvedValue(mockDomains);
+
+    const result = await listSendingDomains();
+
+    expect(client.sendingDomains.getList).toHaveBeenCalledWith();
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe("text");
+    expect(result.content[0].text).toContain("example.com");
+    expect(result.content[0].text).toContain("ID: 1");
+    expect(result.content[0].text).toContain("test.com");
+    expect(result.content[0].text).toContain("DNS verified: true");
+    expect(result.content[0].text).toContain("DNS verified: false");
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("should handle empty domains list", async () => {
+    (client.sendingDomains.getList as jest.Mock).mockResolvedValue({
+      data: [],
+    });
+
+    const result = await listSendingDomains();
+
+    expect(result.content[0].text).toContain("No sending domains found");
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("should require MAILTRAP_ACCOUNT_ID", async () => {
+    delete process.env.MAILTRAP_ACCOUNT_ID;
+
+    const result = await listSendingDomains();
+
+    expect(client.sendingDomains.getList).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain("MAILTRAP_ACCOUNT_ID");
+    expect(result.isError).toBe(true);
+  });
+
+  it("should handle API failure", async () => {
+    (client.sendingDomains.getList as jest.Mock).mockRejectedValue(
+      new Error("Network error")
+    );
+
+    const result = await listSendingDomains();
+
+    expect(result.content[0].text).toContain("Failed to list sending domains");
+    expect(result.content[0].text).toContain("Network error");
+    expect(result.isError).toBe(true);
+  });
+});

--- a/src/tools/sendingDomains/createSendingDomain.ts
+++ b/src/tools/sendingDomains/createSendingDomain.ts
@@ -1,0 +1,52 @@
+import { client } from "../../client";
+import { buildSetupInstructionsSection } from "./utils/setupInstructions";
+
+async function createSendingDomain({
+  domain_name,
+}: {
+  domain_name: string;
+}): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    if (!client) {
+      throw new Error("MAILTRAP_API_TOKEN environment variable is required");
+    }
+
+    const accountId = process.env.MAILTRAP_ACCOUNT_ID;
+    if (!accountId || Number.isNaN(Number(accountId))) {
+      throw new Error(
+        "MAILTRAP_ACCOUNT_ID environment variable is required for sending domains"
+      );
+    }
+
+    const domain = await client.sendingDomains.create({ domain_name });
+
+    let text = [
+      `Sending domain "${domain_name}" created successfully.`,
+      `Domain ID: ${domain.id}`,
+    ].join("\n");
+    text += buildSetupInstructionsSection(
+      domain.domain_name,
+      domain.dns_records
+    );
+
+    return {
+      content: [{ type: "text", text }],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to create sending domain: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default createSendingDomain;

--- a/src/tools/sendingDomains/deleteSendingDomain.ts
+++ b/src/tools/sendingDomains/deleteSendingDomain.ts
@@ -1,0 +1,47 @@
+import { client } from "../../client";
+
+async function deleteSendingDomain({
+  sending_domain_id,
+}: {
+  sending_domain_id: number;
+}): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    if (!client) {
+      throw new Error("MAILTRAP_API_TOKEN environment variable is required");
+    }
+
+    const accountId = process.env.MAILTRAP_ACCOUNT_ID;
+    if (!accountId || Number.isNaN(Number(accountId))) {
+      throw new Error(
+        "MAILTRAP_ACCOUNT_ID environment variable is required for sending domains"
+      );
+    }
+
+    await client.sendingDomains.delete(sending_domain_id);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Sending domain with ID ${sending_domain_id} deleted successfully.`,
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to delete sending domain: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default deleteSendingDomain;

--- a/src/tools/sendingDomains/getSendingDomain.ts
+++ b/src/tools/sendingDomains/getSendingDomain.ts
@@ -1,0 +1,79 @@
+import { client } from "../../client";
+import { buildSetupInstructionsSection } from "./utils/setupInstructions";
+
+async function getSendingDomain({
+  sending_domain_id,
+  include_setup_instructions,
+}: {
+  sending_domain_id: number;
+  include_setup_instructions?: boolean;
+}): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    if (!client) {
+      throw new Error("MAILTRAP_API_TOKEN environment variable is required");
+    }
+
+    const accountId = process.env.MAILTRAP_ACCOUNT_ID;
+    if (!accountId || Number.isNaN(Number(accountId))) {
+      throw new Error(
+        "MAILTRAP_ACCOUNT_ID environment variable is required for sending domains"
+      );
+    }
+
+    const domain = await client.sendingDomains.get(sending_domain_id);
+
+    const dnsSummary =
+      domain.dns_records?.length > 0
+        ? domain.dns_records
+            .map(
+              (r) =>
+                `  - ${r.key}: type=${r.type}, name=${
+                  r.name || "(root)"
+                }, status=${r.status}`
+            )
+            .join("\n")
+        : "  (no DNS records)";
+
+    let text = [
+      `Domain: ${domain.domain_name} (ID: ${domain.id})`,
+      `Demo: ${domain.demo}`,
+      `Compliance: ${domain.compliance_status}`,
+      `DNS verified: ${domain.dns_verified}`,
+      domain.dns_verified_at
+        ? `DNS verified at: ${domain.dns_verified_at}`
+        : null,
+      "",
+      "DNS records:",
+      dnsSummary,
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    if (include_setup_instructions) {
+      text += buildSetupInstructionsSection(
+        domain.domain_name,
+        domain.dns_records
+      );
+    }
+
+    return {
+      content: [{ type: "text", text }],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to get sending domain: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default getSendingDomain;

--- a/src/tools/sendingDomains/index.ts
+++ b/src/tools/sendingDomains/index.ts
@@ -1,0 +1,21 @@
+import {
+  listSendingDomainsSchema,
+  getSendingDomainSchema,
+  createSendingDomainSchema,
+  deleteSendingDomainSchema,
+} from "./schema";
+import listSendingDomains from "./listSendingDomains";
+import getSendingDomain from "./getSendingDomain";
+import createSendingDomain from "./createSendingDomain";
+import deleteSendingDomain from "./deleteSendingDomain";
+
+export {
+  listSendingDomainsSchema,
+  listSendingDomains,
+  getSendingDomainSchema,
+  getSendingDomain,
+  createSendingDomainSchema,
+  createSendingDomain,
+  deleteSendingDomainSchema,
+  deleteSendingDomain,
+};

--- a/src/tools/sendingDomains/listSendingDomains.ts
+++ b/src/tools/sendingDomains/listSendingDomains.ts
@@ -1,0 +1,58 @@
+import { client } from "../../client";
+
+async function listSendingDomains(): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    if (!client) {
+      throw new Error("MAILTRAP_API_TOKEN environment variable is required");
+    }
+
+    const accountId = process.env.MAILTRAP_ACCOUNT_ID;
+    if (!accountId || Number.isNaN(Number(accountId))) {
+      throw new Error(
+        "MAILTRAP_ACCOUNT_ID environment variable is required for sending domains"
+      );
+    }
+
+    const response = await client.sendingDomains.getList();
+    const domains = response?.data ?? [];
+
+    if (domains.length === 0) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: "No sending domains found in your Mailtrap account.",
+          },
+        ],
+      };
+    }
+
+    const lines = domains.map(
+      (d) =>
+        `• ${d.domain_name} (ID: ${d.id})\n  DNS verified: ${d.dns_verified} | Compliance: ${d.compliance_status}`
+    );
+    const text = `Sending domains (${domains.length}):\n\n${lines.join(
+      "\n\n"
+    )}`;
+
+    return {
+      content: [{ type: "text", text }],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to list sending domains: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default listSendingDomains;

--- a/src/tools/sendingDomains/schema.ts
+++ b/src/tools/sendingDomains/schema.ts
@@ -1,0 +1,53 @@
+const listSendingDomainsSchema = {
+  type: "object",
+  properties: {},
+  additionalProperties: false,
+};
+
+const getSendingDomainSchema = {
+  type: "object",
+  properties: {
+    sending_domain_id: {
+      type: "number",
+      description: "Sending domain ID",
+    },
+    include_setup_instructions: {
+      type: "boolean",
+      description: "If true, append DNS setup instructions to the response.",
+      default: false,
+    },
+  },
+  required: ["sending_domain_id"],
+  additionalProperties: false,
+};
+
+const createSendingDomainSchema = {
+  type: "object",
+  properties: {
+    domain_name: {
+      type: "string",
+      description: "Domain name (e.g. example.com)",
+    },
+  },
+  required: ["domain_name"],
+  additionalProperties: false,
+};
+
+const deleteSendingDomainSchema = {
+  type: "object",
+  properties: {
+    sending_domain_id: {
+      type: "number",
+      description: "Sending domain ID to delete",
+    },
+  },
+  required: ["sending_domain_id"],
+  additionalProperties: false,
+};
+
+export {
+  listSendingDomainsSchema,
+  getSendingDomainSchema,
+  createSendingDomainSchema,
+  deleteSendingDomainSchema,
+};

--- a/src/tools/sendingDomains/utils/setupInstructions.ts
+++ b/src/tools/sendingDomains/utils/setupInstructions.ts
@@ -1,0 +1,53 @@
+const DOCS_DNS_RECORDS =
+  "https://docs.mailtrap.io/email-api-smtp/help/glossary#dns-record-types";
+const DOCS_ADD_RECORDS =
+  "https://docs.mailtrap.io/email-api-smtp/setup/sending-domain";
+
+export type DnsRecord = {
+  key: string;
+  type: string;
+  name: string;
+  value: string;
+  status: string;
+};
+
+export function formatSetupInstructionsDnsTable(
+  dnsRecords: DnsRecord[]
+): string {
+  if (!dnsRecords?.length) {
+    return "  (no DNS records to add)";
+  }
+  const rows = dnsRecords.map(
+    (r) =>
+      `  ${r.key}\t${r.type}\t${r.name || "(root)"}\t${r.value}\t${r.status}`
+  );
+  return ["  Key\tType\tName\tValue\tStatus", ...rows].join("\n");
+}
+
+export function buildSetupInstructionsSection(
+  domainName: string,
+  dnsRecords: DnsRecord[] | undefined
+): string {
+  const records = dnsRecords ?? [];
+  const what = [
+    "The domain has been added to Mailtrap. To verify ownership, add the DNS records below to your domain provider.",
+    `Learn more: what DNS records are (${DOCS_DNS_RECORDS}), how to add DNS records (${DOCS_ADD_RECORDS}).`,
+  ].join(" ");
+  const why = "Verification proves you own the domain.";
+  const dnsTable = formatSetupInstructionsDnsTable(records);
+  return [
+    "",
+    "---",
+    "",
+    `Add DNS records for ${domainName}`,
+    "",
+    "What?",
+    what,
+    "",
+    "Why?",
+    why,
+    "",
+    "DNS records to add:",
+    dnsTable,
+  ].join("\n");
+}


### PR DESCRIPTION
## Changes

- Add sending-domains tools
  - CR~~U~~D + display of DNS setup instructions

## Images and GIFs

<img width="731" height="682" alt="Screenshot 2026-03-18 at 17 53 54" src="https://github.com/user-attachments/assets/1764d183-1f54-4060-ac81-463755ae4dc1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added four new sending domain management tools: `list-sending-domains`, `get-sending-domain`, `create-sending-domain`, and `delete-sending-domain`
  * `get-sending-domain` supports an optional parameter to retrieve DNS setup instructions

* **Documentation**
  * Updated documentation with sending domain tool usage examples and parameter specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->