### PR TITLE
Extend show-sandbox-email-message tool with spam and HTML analysis

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -115,7 +115,7 @@ const tools = [
   {
     name: "show-sandbox-email-message",
     description:
-      "Show sandbox email message details and content from the sandbox test inbox",
+      "Show sandbox email message details and content from the sandbox test inbox. Optionally include spam report (SpamAssassin score) and HTML analysis (client compatibility) for email testing workflows.",
     inputSchema: showEmailMessageSchema,
     handler: showEmailMessage,
   },

--- a/src/tools/sandbox/__tests__/showEmailMessage.test.ts
+++ b/src/tools/sandbox/__tests__/showEmailMessage.test.ts
@@ -8,6 +8,8 @@ jest.mock("../../../client", () => ({
         showEmailMessage: jest.fn(),
         getHtmlMessage: jest.fn(),
         getTextMessage: jest.fn(),
+        getSpamScore: jest.fn(),
+        getHtmlAnalysis: jest.fn(),
       },
     },
   },
@@ -197,6 +199,107 @@ describe("showEmailMessage", () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("Sandbox client is not available");
     consoleErrorSpy.mockRestore();
+  });
+
+  it("should include spam report when include_spam_report is true", async () => {
+    const mockSpamReport = {
+      res: {
+        score: 2.5,
+        report: "SpamAssassin report",
+        rules: ["RULE_A", "RULE_B"],
+      },
+    };
+    (sandboxClient as any).testing.messages.getSpamScore.mockResolvedValue(
+      mockSpamReport
+    );
+
+    const result = await showEmailMessage({
+      message_id: 1,
+      include_spam_report: true,
+    });
+
+    expect(
+      (sandboxClient as any).testing.messages.getSpamScore
+    ).toHaveBeenCalledWith(123, 1);
+    expect(result.content[0].text).toContain("--- Spam Report ---");
+    expect(result.content[0].text).toContain("Spam score: 2.5");
+    expect(result.content[0].text).toContain("SpamAssassin report");
+    expect(result.content[0].text).toContain("RULE_A");
+  });
+
+  it("should include HTML analysis when include_html_analysis is true", async () => {
+    const mockHtmlAnalysis = {
+      html_compatibility_score: 85,
+      text_compatibility_score: 100,
+      problematic_elements: ["max-width", "style tag"],
+    };
+    (sandboxClient as any).testing.messages.getHtmlAnalysis.mockResolvedValue(
+      mockHtmlAnalysis
+    );
+
+    const result = await showEmailMessage({
+      message_id: 1,
+      include_html_analysis: true,
+    });
+
+    expect(
+      (sandboxClient as any).testing.messages.getHtmlAnalysis
+    ).toHaveBeenCalledWith(123, 1);
+    expect(result.content[0].text).toContain("--- HTML Analysis ---");
+    expect(result.content[0].text).toContain("HTML compatibility score: 85");
+    expect(result.content[0].text).toContain("Text compatibility score: 100");
+    expect(result.content[0].text).toContain("max-width");
+  });
+
+  it("should not call getSpamScore or getHtmlAnalysis when flags are false", async () => {
+    await showEmailMessage({ message_id: 1 });
+
+    expect(
+      (sandboxClient as any).testing.messages.getSpamScore
+    ).not.toHaveBeenCalled();
+    expect(
+      (sandboxClient as any).testing.messages.getHtmlAnalysis
+    ).not.toHaveBeenCalled();
+  });
+
+  it("should handle spam report fetch failure gracefully", async () => {
+    (sandboxClient as any).testing.messages.getSpamScore.mockRejectedValue(
+      new Error("Spam API error")
+    );
+    const consoleWarnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+
+    const result = await showEmailMessage({
+      message_id: 1,
+      include_spam_report: true,
+    });
+
+    expect(result.content[0].text).toContain("--- Spam Report ---");
+    expect(result.content[0].text).toContain(
+      "Spam report could not be retrieved"
+    );
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("should handle HTML analysis fetch failure gracefully", async () => {
+    (sandboxClient as any).testing.messages.getHtmlAnalysis.mockRejectedValue(
+      new Error("Analyze API error")
+    );
+    const consoleWarnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+
+    const result = await showEmailMessage({
+      message_id: 1,
+      include_html_analysis: true,
+    });
+
+    expect(result.content[0].text).toContain("--- HTML Analysis ---");
+    expect(result.content[0].text).toContain(
+      "HTML analysis could not be retrieved"
+    );
+    consoleWarnSpy.mockRestore();
   });
 
   it("should handle API errors", async () => {

--- a/src/tools/sandbox/schemas/showEmailMessage.ts
+++ b/src/tools/sandbox/schemas/showEmailMessage.ts
@@ -5,6 +5,18 @@ const showEmailMessageSchema = {
       type: "number",
       description: "ID of the sandbox email message to retrieve",
     },
+    include_spam_report: {
+      type: "boolean",
+      description:
+        "When true, include spam report (SpamAssassin score and details). Critical for deliverability testing.",
+      default: false,
+    },
+    include_html_analysis: {
+      type: "boolean",
+      description:
+        "When true, include HTML analysis (client compatibility, problematic elements). Critical for email client testing.",
+      default: false,
+    },
   },
   required: ["message_id"],
   additionalProperties: false,

--- a/src/tools/sandbox/showSandboxEmailMessage.ts
+++ b/src/tools/sandbox/showSandboxEmailMessage.ts
@@ -1,8 +1,50 @@
 import { sandboxClient } from "../../client";
 import { ShowEmailMessageRequest } from "../../types/mailtrap";
 
+function formatSpamReport(data: unknown): string {
+  if (data == null) return "No data.";
+  const o =
+    typeof data === "object" && data !== null && "res" in data
+      ? (data as { res: Record<string, unknown> }).res
+      : (data as Record<string, unknown>);
+  if (typeof o === "object" && o !== null) {
+    const lines: string[] = [];
+    if (typeof o.score === "number")
+      lines.push(`Spam score: ${o.score} (threshold typically 5)`);
+    if (typeof o.report === "string") lines.push(`Report: ${o.report}`);
+    if (Array.isArray(o.rules))
+      lines.push(
+        `Rules: ${(o.rules as unknown[]).map(String).join(", ") || "none"}`
+      );
+    if (lines.length) return lines.join("\n");
+  }
+  return JSON.stringify(data, null, 2);
+}
+
+function formatHtmlAnalysis(data: unknown): string {
+  if (data == null) return "No data.";
+  if (typeof data === "object") {
+    const o = data as Record<string, unknown>;
+    const lines: string[] = [];
+    if (typeof o.html_compatibility_score === "number")
+      lines.push(`HTML compatibility score: ${o.html_compatibility_score}`);
+    if (typeof o.text_compatibility_score === "number")
+      lines.push(`Text compatibility score: ${o.text_compatibility_score}`);
+    if (Array.isArray(o.problematic_elements) && o.problematic_elements.length)
+      lines.push(
+        `Problematic elements: ${(o.problematic_elements as unknown[]).join(
+          ", "
+        )}`
+      );
+    if (lines.length) return lines.join("\n");
+  }
+  return JSON.stringify(data, null, 2);
+}
+
 async function showEmailMessage({
   message_id,
+  include_spam_report = false,
+  include_html_analysis = false,
 }: ShowEmailMessageRequest): Promise<{ content: any[]; isError?: boolean }> {
   try {
     const { MAILTRAP_TEST_INBOX_ID } = process.env;
@@ -95,6 +137,39 @@ async function showEmailMessage({
 
     if (!htmlContent && !textContent) {
       contentText += "\n\nNote: Message body content could not be retrieved.";
+    }
+
+    if (include_spam_report) {
+      try {
+        const spamReport = await sandboxClient.testing.messages.getSpamScore(
+          inboxId,
+          message_id
+        );
+        contentText += `\n\n--- Spam Report ---\n${formatSpamReport(
+          spamReport
+        )}`;
+      } catch (error) {
+        console.warn("Could not retrieve spam report:", error);
+        contentText +=
+          "\n\n--- Spam Report ---\nSpam report could not be retrieved.";
+      }
+    }
+
+    if (include_html_analysis) {
+      try {
+        const htmlAnalysis =
+          await sandboxClient.testing.messages.getHtmlAnalysis(
+            inboxId,
+            message_id
+          );
+        contentText += `\n\n--- HTML Analysis ---\n${formatHtmlAnalysis(
+          htmlAnalysis
+        )}`;
+      } catch (error) {
+        console.warn("Could not retrieve HTML analysis:", error);
+        contentText +=
+          "\n\n--- HTML Analysis ---\nHTML analysis could not be retrieved.";
+      }
     }
 
     return {

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -64,6 +64,10 @@ export interface GetMessagesRequest {
 
 export interface ShowEmailMessageRequest {
   message_id: number;
+  /** When true, include spam report (SpamAssassin score and details). Useful for deliverability testing. */
+  include_spam_report?: boolean;
+  /** When true, include HTML analysis (compatibility, problematic elements). Useful for email client testing. */
+  include_html_analysis?: boolean;
 }
 
 /** From/to filter operators (case-insensitive). */


### PR DESCRIPTION
## Changes

- Extend show-sandbox-email-message tool with spam and HTML analysis

## Images and GIFs

<img width="511" height="959" alt="Screenshot 2026-03-19 at 09 05 07" src="https://github.com/user-attachments/assets/4a722859-e66d-4dcd-a738-467d145b9405" />
