### PR TITLE
Make DEFAULT_FROM_EMAIL and MAILTRAP_TEST_INBOX_ID config/env params optional

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,9 +51,9 @@ Schema files define a JSON Schema–shaped object for MCP; optional Zod schemas 
 ### Environment Variables Required
 
 - `MAILTRAP_API_TOKEN`: Required API token from Mailtrap
-- `DEFAULT_FROM_EMAIL`: Default sender email address
 - `MAILTRAP_ACCOUNT_ID`: Required for templates, stats, email logs, sandbox list/show, and sending domains. Optional only for send-email and send-sandbox-email.
-- `MAILTRAP_TEST_INBOX_ID`: Required for sandbox tools - test inbox ID for sandbox mode operations
+- `DEFAULT_FROM_EMAIL`: Optional. Default sender email when the tool does not receive a `from` parameter (send-email, send-sandbox-email).
+- `MAILTRAP_TEST_INBOX_ID`: Optional. Default test inbox ID for sandbox tools when the tool does not receive a `test_inbox_id` parameter. Enables switching inboxes per call via parameters.
 
 ### Testing Setup
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,12 @@ Before using this MCP server, you need to:
 **Required Environment Variables:**
 
 - `MAILTRAP_API_TOKEN` - Required for all functionality
-- `DEFAULT_FROM_EMAIL` - Required for all email sending operations
 - `MAILTRAP_ACCOUNT_ID` - Required for templates, stats, email logs, sandbox list/show, and sending domains. Optional only for send-email and send-sandbox-email.
-- `MAILTRAP_TEST_INBOX_ID` - Required for sandbox tools (send, list messages, show message)
+
+**Optional (can be passed as tool parameters instead):**
+
+- `DEFAULT_FROM_EMAIL` - Default sender email when `from` is not provided to send-email or send-sandbox-email. Enables switching sender per call via the `from` parameter.
+- `MAILTRAP_TEST_INBOX_ID` - Default test inbox ID for sandbox tools when `test_inbox_id` is not provided. Enables switching between inboxes per call via the `test_inbox_id` parameter.
 
 ## Quick Install
 
@@ -321,7 +324,7 @@ Sends an email to your Mailtrap test inbox for development and testing purposes.
 - `category` (optional): Email category for tracking
 
 > [!NOTE]
-> The `MAILTRAP_TEST_INBOX_ID` environment variable must be configured for sandbox emails to work. This variable is **only** required for sandbox functionality and is not needed for regular transactional emails or template management.
+> For sandbox tools, provide `test_inbox_id` in the tool call or set the `MAILTRAP_TEST_INBOX_ID` environment variable. You can switch between inboxes per call by passing `test_inbox_id`.
 
 ### get-sandbox-messages
 
@@ -540,7 +543,7 @@ node dist/mcpb-server.js 2>&1 | jq 'select(.level == "debug")'
 Common issues:
 
 1. Missing API Token: ensure `MAILTRAP_API_TOKEN` is set
-2. Sandbox not working: verify `MAILTRAP_TEST_INBOX_ID` is configured
+2. Sandbox not working: provide `test_inbox_id` in the tool call or set `MAILTRAP_TEST_INBOX_ID` env
 3. Timeout errors: check network connectivity and Mailtrap API status
 4. Validation errors: ensure all required fields are provided
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -18,26 +18,25 @@ const client = (
     : null
 ) as MailtrapClient;
 
-// Create a sandbox client instance
-const { MAILTRAP_TEST_INBOX_ID } = process.env;
-
-const sandboxClient = (
-  MAILTRAP_API_TOKEN &&
-  MAILTRAP_TEST_INBOX_ID &&
-  !Number.isNaN(Number(process.env.MAILTRAP_TEST_INBOX_ID))
-    ? new MailtrapClient({
-        token: MAILTRAP_API_TOKEN,
-        userAgent: config.USER_AGENT,
-        testInboxId: Number(process.env.MAILTRAP_TEST_INBOX_ID),
-        sandbox: true,
-        // conditionally set accountId if it's a valid number
-        ...(process.env.MAILTRAP_ACCOUNT_ID &&
-        !Number.isNaN(Number(process.env.MAILTRAP_ACCOUNT_ID))
-          ? { accountId: Number(process.env.MAILTRAP_ACCOUNT_ID) }
-          : {}),
-      })
-    : null
-) as MailtrapClient;
+/**
+ * Returns a sandbox MailtrapClient for the given test inbox ID.
+ * Use this when you have an inbox ID from tool parameters or env (MAILTRAP_TEST_INBOX_ID).
+ */
+function getSandboxClient(inboxId: number): MailtrapClient {
+  if (!MAILTRAP_API_TOKEN) {
+    throw new Error("MAILTRAP_API_TOKEN environment variable is required");
+  }
+  return new MailtrapClient({
+    token: MAILTRAP_API_TOKEN,
+    userAgent: config.USER_AGENT,
+    testInboxId: inboxId,
+    sandbox: true,
+    ...(process.env.MAILTRAP_ACCOUNT_ID &&
+    !Number.isNaN(Number(process.env.MAILTRAP_ACCOUNT_ID))
+      ? { accountId: Number(process.env.MAILTRAP_ACCOUNT_ID) }
+      : {}),
+  });
+}
 
 // eslint-disable-next-line import/prefer-default-export
-export { client, sandboxClient };
+export { client, getSandboxClient };

--- a/src/tools/sandbox/__tests__/getMessages.test.ts
+++ b/src/tools/sandbox/__tests__/getMessages.test.ts
@@ -1,17 +1,15 @@
 import getMessages from "../getSandboxMessages";
-import { sandboxClient } from "../../../client";
+import { getSandboxClient } from "../../../client";
 
+const mockGet = jest.fn();
 jest.mock("../../../client", () => ({
-  sandboxClient: {
-    testing: {
-      messages: {
-        get: jest.fn(),
-      },
-    },
-  },
+  getSandboxClient: jest.fn(() => ({
+    testing: { messages: { get: mockGet } },
+  })),
 }));
 
 describe("getMessages", () => {
+  const inboxId = 123;
   const mockMessages = [
     {
       id: 1,
@@ -36,8 +34,11 @@ describe("getMessages", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.resetModules();
-    (sandboxClient as any).testing.messages.get.mockResolvedValue(mockMessages);
-    Object.assign(process.env, { MAILTRAP_TEST_INBOX_ID: "123" });
+    mockGet.mockResolvedValue(mockMessages);
+    (getSandboxClient as jest.Mock).mockReturnValue({
+      testing: { messages: { get: mockGet } },
+    });
+    Object.assign(process.env, { MAILTRAP_TEST_INBOX_ID: String(inboxId) });
   });
 
   afterEach(() => {
@@ -47,10 +48,7 @@ describe("getMessages", () => {
   it("should get messages successfully", async () => {
     const result = await getMessages({});
 
-    expect((sandboxClient as any).testing.messages.get).toHaveBeenCalledWith(
-      123,
-      undefined
-    );
+    expect(mockGet).toHaveBeenCalledWith(inboxId, undefined);
 
     expect(result).toEqual({
       content: [
@@ -63,7 +61,7 @@ describe("getMessages", () => {
   });
 
   it("should handle empty messages list", async () => {
-    (sandboxClient as any).testing.messages.get.mockResolvedValue([]);
+    mockGet.mockResolvedValue([]);
 
     const result = await getMessages({});
 
@@ -78,7 +76,7 @@ describe("getMessages", () => {
   });
 
   it("should handle null messages response", async () => {
-    (sandboxClient as any).testing.messages.get.mockResolvedValue(null);
+    mockGet.mockResolvedValue(null);
 
     const result = await getMessages({});
 
@@ -92,7 +90,7 @@ describe("getMessages", () => {
     });
   });
 
-  it("should handle missing MAILTRAP_TEST_INBOX_ID", async () => {
+  it("should handle missing test_inbox_id and MAILTRAP_TEST_INBOX_ID", async () => {
     const consoleErrorSpy = jest
       .spyOn(console, "error")
       .mockImplementation(() => {});
@@ -106,41 +104,22 @@ describe("getMessages", () => {
     );
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain(
-      "MAILTRAP_TEST_INBOX_ID environment variable is required"
+      "Provide test_inbox_id or set MAILTRAP_TEST_INBOX_ID"
     );
     consoleErrorSpy.mockRestore();
   });
 
-  it("should handle missing sandbox client", async () => {
-    const consoleErrorSpy = jest
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
-    // Mock sandboxClient as null for this test
-    jest.doMock("../../../client", () => ({
-      sandboxClient: null,
-    }));
+  it("should use test_inbox_id parameter when provided", async () => {
+    const result = await getMessages({ test_inbox_id: 456 });
 
-    // Re-import the module to get the mocked version
-    jest.resetModules();
-    const getMessagesModule = (await import("../getSandboxMessages")).default;
-    const result = await getMessagesModule({});
-
-    // Restore the original mock
-    jest.dontMock("../../../client");
-    jest.resetModules();
-
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "Error getting messages:",
-      expect.anything()
-    );
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("Sandbox client is not available");
-    consoleErrorSpy.mockRestore();
+    expect(getSandboxClient).toHaveBeenCalledWith(456);
+    expect(mockGet).toHaveBeenCalledWith(456, undefined);
+    expect(result.content[0].text).toContain("Found 2 message(s)");
   });
 
   it("should handle API errors", async () => {
     const mockError = new Error("API Error");
-    (sandboxClient as any).testing.messages.get.mockRejectedValue(mockError);
+    mockGet.mockRejectedValue(mockError);
     const consoleErrorSpy = jest
       .spyOn(console, "error")
       .mockImplementation(() => {});
@@ -160,45 +139,34 @@ describe("getMessages", () => {
   it("should pass page parameter to SDK", async () => {
     await getMessages({ page: 2 });
 
-    expect((sandboxClient as any).testing.messages.get).toHaveBeenCalledWith(
-      123,
-      { page: 2 }
-    );
+    expect(mockGet).toHaveBeenCalledWith(inboxId, { page: 2 });
   });
 
   it("should pass last_id parameter to SDK", async () => {
     await getMessages({ last_id: 100 });
 
-    expect((sandboxClient as any).testing.messages.get).toHaveBeenCalledWith(
-      123,
-      { last_id: 100 }
-    );
+    expect(mockGet).toHaveBeenCalledWith(inboxId, { last_id: 100 });
   });
 
   it("should pass search parameter to SDK", async () => {
     await getMessages({ search: "test query" });
 
-    expect((sandboxClient as any).testing.messages.get).toHaveBeenCalledWith(
-      123,
-      { search: "test query" }
-    );
+    expect(mockGet).toHaveBeenCalledWith(inboxId, { search: "test query" });
   });
 
   it("should pass multiple parameters to SDK", async () => {
     await getMessages({ page: 1, search: "test" });
 
-    expect((sandboxClient as any).testing.messages.get).toHaveBeenCalledWith(
-      123,
-      { page: 1, search: "test" }
-    );
+    expect(mockGet).toHaveBeenCalledWith(inboxId, { page: 1, search: "test" });
   });
 
   it("should pass all parameters to SDK", async () => {
     await getMessages({ page: 2, last_id: 100, search: "test query" });
 
-    expect((sandboxClient as any).testing.messages.get).toHaveBeenCalledWith(
-      123,
-      { page: 2, last_id: 100, search: "test query" }
-    );
+    expect(mockGet).toHaveBeenCalledWith(inboxId, {
+      page: 2,
+      last_id: 100,
+      search: "test query",
+    });
   });
 });

--- a/src/tools/sandbox/__tests__/sendSandboxEmail.test.ts
+++ b/src/tools/sandbox/__tests__/sendSandboxEmail.test.ts
@@ -1,14 +1,15 @@
 import sendSandboxEmail from "../sendSandboxEmail";
-import { sandboxClient } from "../../../client";
+import { getSandboxClient } from "../../../client";
 
+const mockSend = jest.fn();
 jest.mock("../../../client", () => ({
-  sandboxClient: {
-    send: jest.fn(),
-  },
+  getSandboxClient: jest.fn(() => ({ send: mockSend })),
 }));
 
 describe("sendSandboxEmail", () => {
+  const inboxId = 123;
   const mockEmailData = {
+    test_inbox_id: inboxId,
     from: "default@example.com",
     to: "recipient@example.com",
     subject: "Test Subject",
@@ -25,8 +26,12 @@ describe("sendSandboxEmail", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.resetModules();
-    (sandboxClient as any).send.mockResolvedValue(mockResponse);
-    Object.assign(process.env, { MAILTRAP_TEST_INBOX_ID: "123" });
+    mockSend.mockResolvedValue(mockResponse);
+    (getSandboxClient as jest.Mock).mockReturnValue({ send: mockSend });
+    Object.assign(process.env, {
+      MAILTRAP_TEST_INBOX_ID: String(inboxId),
+      DEFAULT_FROM_EMAIL: "default@example.com",
+    });
   });
 
   afterEach(() => {
@@ -36,7 +41,7 @@ describe("sendSandboxEmail", () => {
   it("should send sandbox email successfully with default from address", async () => {
     const result = await sendSandboxEmail(mockEmailData);
 
-    expect((sandboxClient as any).send).toHaveBeenCalledWith({
+    expect(mockSend).toHaveBeenCalledWith({
       from: { email: "default@example.com" },
       to: [{ email: mockEmailData.to }],
       subject: mockEmailData.subject,
@@ -65,9 +70,10 @@ describe("sendSandboxEmail", () => {
     const result = await sendSandboxEmail({
       ...mockEmailData,
       from: customFrom,
+      test_inbox_id: inboxId,
     });
 
-    expect((sandboxClient as any).send).toHaveBeenCalledWith({
+    expect(mockSend).toHaveBeenCalledWith({
       from: { email: customFrom },
       to: [{ email: mockEmailData.to }],
       subject: mockEmailData.subject,
@@ -100,7 +106,7 @@ describe("sendSandboxEmail", () => {
       bcc,
     });
 
-    expect((sandboxClient as any).send).toHaveBeenCalledWith({
+    expect(mockSend).toHaveBeenCalledWith({
       from: { email: "default@example.com" },
       to: [{ email: mockEmailData.to }],
       subject: mockEmailData.subject,
@@ -133,7 +139,7 @@ describe("sendSandboxEmail", () => {
       html,
     });
 
-    expect((sandboxClient as any).send).toHaveBeenCalledWith({
+    expect(mockSend).toHaveBeenCalledWith({
       from: { email: "default@example.com" },
       to: [{ email: mockEmailData.to }],
       subject: mockEmailData.subject,
@@ -165,7 +171,7 @@ describe("sendSandboxEmail", () => {
       html,
     });
 
-    expect((sandboxClient as any).send).toHaveBeenCalledWith({
+    expect(mockSend).toHaveBeenCalledWith({
       from: { email: "default@example.com" },
       to: [{ email: mockEmailData.to }],
       subject: mockEmailData.subject,
@@ -196,7 +202,7 @@ describe("sendSandboxEmail", () => {
       category,
     });
 
-    expect((sandboxClient as any).send).toHaveBeenCalledWith({
+    expect(mockSend).toHaveBeenCalledWith({
       from: { email: "default@example.com" },
       to: [{ email: mockEmailData.to }],
       subject: mockEmailData.subject,
@@ -227,7 +233,7 @@ describe("sendSandboxEmail", () => {
       to: toEmails,
     });
 
-    expect((sandboxClient as any).send).toHaveBeenCalledWith({
+    expect(mockSend).toHaveBeenCalledWith({
       from: { email: "default@example.com" },
       to: [
         { email: "user1@example.com" },
@@ -260,7 +266,7 @@ describe("sendSandboxEmail", () => {
       to: singleEmail,
     });
 
-    expect((sandboxClient as any).send).toHaveBeenCalledWith({
+    expect(mockSend).toHaveBeenCalledWith({
       from: { email: "default@example.com" },
       to: [{ email: singleEmail }],
       subject: mockEmailData.subject,
@@ -289,7 +295,7 @@ describe("sendSandboxEmail", () => {
       to: multipleRecipients,
     });
 
-    expect((sandboxClient as any).send).toHaveBeenCalledWith({
+    expect(mockSend).toHaveBeenCalledWith({
       from: { email: "default@example.com" },
       to: [
         { email: "recipient1@example.com" },
@@ -326,29 +332,30 @@ describe("sendSandboxEmail", () => {
       consoleErrorSpy.mockRestore();
     });
 
-    it("should throw error when MAILTRAP_TEST_INBOX_ID is not set", async () => {
+    it("should throw error when test_inbox_id and MAILTRAP_TEST_INBOX_ID are not set", async () => {
       delete process.env.MAILTRAP_TEST_INBOX_ID;
 
-      const result = await sendSandboxEmail(mockEmailData);
+      const result = await sendSandboxEmail({
+        from: mockEmailData.from,
+        to: mockEmailData.to,
+        subject: mockEmailData.subject,
+        text: mockEmailData.text,
+      });
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "Error sending sandbox email:",
         expect.anything()
       );
-      expect((sandboxClient as any).send).not.toHaveBeenCalled();
-      expect(result).toEqual({
-        content: [
-          {
-            type: "text",
-            text: "Failed to send sandbox email: MAILTRAP_TEST_INBOX_ID environment variable is required for sandbox mode",
-          },
-        ],
-        isError: true,
-      });
+      expect(mockSend).not.toHaveBeenCalled();
+      expect(result.content[0].text).toContain(
+        "Provide test_inbox_id or set MAILTRAP_TEST_INBOX_ID"
+      );
+      expect(result.isError).toBe(true);
     });
 
     it("should throw error when neither HTML nor TEXT is provided", async () => {
       const result = await sendSandboxEmail({
+        test_inbox_id: inboxId,
         from: "default@example.com",
         to: mockEmailData.to,
         subject: mockEmailData.subject,
@@ -358,7 +365,7 @@ describe("sendSandboxEmail", () => {
         "Error sending sandbox email:",
         expect.anything()
       );
-      expect((sandboxClient as any).send).not.toHaveBeenCalled();
+      expect(mockSend).not.toHaveBeenCalled();
       expect(result).toEqual({
         content: [
           {
@@ -372,7 +379,7 @@ describe("sendSandboxEmail", () => {
 
     it("should handle client.send failure", async () => {
       const mockError = new Error("Failed to send sandbox email");
-      (sandboxClient as any).send.mockRejectedValue(mockError);
+      mockSend.mockRejectedValue(mockError);
 
       const result = await sendSandboxEmail(mockEmailData);
 

--- a/src/tools/sandbox/__tests__/showEmailMessage.test.ts
+++ b/src/tools/sandbox/__tests__/showEmailMessage.test.ts
@@ -1,21 +1,28 @@
 import showEmailMessage from "../showSandboxEmailMessage";
-import { sandboxClient } from "../../../client";
+import { getSandboxClient } from "../../../client";
+
+const mockShowEmailMessage = jest.fn();
+const mockGetHtmlMessage = jest.fn();
+const mockGetTextMessage = jest.fn();
+const mockGetSpamScore = jest.fn();
+const mockGetHtmlAnalysis = jest.fn();
 
 jest.mock("../../../client", () => ({
-  sandboxClient: {
+  getSandboxClient: jest.fn(() => ({
     testing: {
       messages: {
-        showEmailMessage: jest.fn(),
-        getHtmlMessage: jest.fn(),
-        getTextMessage: jest.fn(),
-        getSpamScore: jest.fn(),
-        getHtmlAnalysis: jest.fn(),
+        showEmailMessage: mockShowEmailMessage,
+        getHtmlMessage: mockGetHtmlMessage,
+        getTextMessage: mockGetTextMessage,
+        getSpamScore: mockGetSpamScore,
+        getHtmlAnalysis: mockGetHtmlAnalysis,
       },
     },
-  },
+  })),
 }));
 
 describe("showEmailMessage", () => {
+  const inboxId = 123;
   const mockMessage = {
     id: 1,
     from_email: "sender@example.com",
@@ -36,16 +43,21 @@ describe("showEmailMessage", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.resetModules();
-    (sandboxClient as any).testing.messages.showEmailMessage.mockResolvedValue(
-      mockMessage
-    );
-    (sandboxClient as any).testing.messages.getHtmlMessage.mockResolvedValue(
-      mockHtmlContent
-    );
-    (sandboxClient as any).testing.messages.getTextMessage.mockResolvedValue(
-      mockTextContent
-    );
-    Object.assign(process.env, { MAILTRAP_TEST_INBOX_ID: "123" });
+    mockShowEmailMessage.mockResolvedValue(mockMessage);
+    mockGetHtmlMessage.mockResolvedValue(mockHtmlContent);
+    mockGetTextMessage.mockResolvedValue(mockTextContent);
+    (getSandboxClient as jest.Mock).mockReturnValue({
+      testing: {
+        messages: {
+          showEmailMessage: mockShowEmailMessage,
+          getHtmlMessage: mockGetHtmlMessage,
+          getTextMessage: mockGetTextMessage,
+          getSpamScore: mockGetSpamScore,
+          getHtmlAnalysis: mockGetHtmlAnalysis,
+        },
+      },
+    });
+    Object.assign(process.env, { MAILTRAP_TEST_INBOX_ID: String(inboxId) });
   });
 
   afterEach(() => {
@@ -55,15 +67,9 @@ describe("showEmailMessage", () => {
   it("should show sandbox email message successfully with HTML and text", async () => {
     const result = await showEmailMessage({ message_id: 1 });
 
-    expect(
-      (sandboxClient as any).testing.messages.showEmailMessage
-    ).toHaveBeenCalledWith(123, 1);
-    expect(
-      (sandboxClient as any).testing.messages.getHtmlMessage
-    ).toHaveBeenCalledWith(123, 1);
-    expect(
-      (sandboxClient as any).testing.messages.getTextMessage
-    ).toHaveBeenCalledWith(123, 1);
+    expect(mockShowEmailMessage).toHaveBeenCalledWith(inboxId, 1);
+    expect(mockGetHtmlMessage).toHaveBeenCalledWith(inboxId, 1);
+    expect(mockGetTextMessage).toHaveBeenCalledWith(inboxId, 1);
 
     expect(result.content[0].text).toContain("Sandbox Email Message Details");
     expect(result.content[0].text).toContain("Message ID: 1");
@@ -79,9 +85,7 @@ describe("showEmailMessage", () => {
     const consoleWarnSpy = jest
       .spyOn(console, "warn")
       .mockImplementation(() => {});
-    (sandboxClient as any).testing.messages.getHtmlMessage.mockRejectedValue(
-      new Error("No HTML")
-    );
+    mockGetHtmlMessage.mockRejectedValue(new Error("No HTML"));
 
     const result = await showEmailMessage({ message_id: 1 });
 
@@ -99,9 +103,7 @@ describe("showEmailMessage", () => {
     const consoleWarnSpy = jest
       .spyOn(console, "warn")
       .mockImplementation(() => {});
-    (sandboxClient as any).testing.messages.getTextMessage.mockRejectedValue(
-      new Error("No text")
-    );
+    mockGetTextMessage.mockRejectedValue(new Error("No text"));
 
     const result = await showEmailMessage({ message_id: 1 });
 
@@ -119,12 +121,8 @@ describe("showEmailMessage", () => {
     const consoleWarnSpy = jest
       .spyOn(console, "warn")
       .mockImplementation(() => {});
-    (sandboxClient as any).testing.messages.getHtmlMessage.mockRejectedValue(
-      new Error("No HTML")
-    );
-    (sandboxClient as any).testing.messages.getTextMessage.mockRejectedValue(
-      new Error("No text")
-    );
+    mockGetHtmlMessage.mockRejectedValue(new Error("No HTML"));
+    mockGetTextMessage.mockRejectedValue(new Error("No text"));
 
     const result = await showEmailMessage({ message_id: 1 });
 
@@ -144,9 +142,7 @@ describe("showEmailMessage", () => {
   });
 
   it("should handle null message response", async () => {
-    (sandboxClient as any).testing.messages.showEmailMessage.mockResolvedValue(
-      null
-    );
+    mockShowEmailMessage.mockResolvedValue(null);
 
     const result = await showEmailMessage({ message_id: 999 });
 
@@ -154,7 +150,7 @@ describe("showEmailMessage", () => {
     expect(result.content[0].text).toContain("Message with ID 999 not found");
   });
 
-  it("should handle missing MAILTRAP_TEST_INBOX_ID", async () => {
+  it("should handle missing test_inbox_id and MAILTRAP_TEST_INBOX_ID", async () => {
     const consoleErrorSpy = jest
       .spyOn(console, "error")
       .mockImplementation(() => {});
@@ -168,37 +164,20 @@ describe("showEmailMessage", () => {
     );
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain(
-      "MAILTRAP_TEST_INBOX_ID environment variable is required"
+      "Provide test_inbox_id or set MAILTRAP_TEST_INBOX_ID"
     );
     consoleErrorSpy.mockRestore();
   });
 
-  it("should handle missing sandbox client", async () => {
-    const consoleErrorSpy = jest
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
-    // Mock sandboxClient as null for this test
-    jest.doMock("../../../client", () => ({
-      sandboxClient: null,
-    }));
+  it("should use test_inbox_id parameter when provided", async () => {
+    const result = await showEmailMessage({
+      test_inbox_id: 456,
+      message_id: 1,
+    });
 
-    // Re-import the module to get the mocked version
-    jest.resetModules();
-    const showEmailMessageModule = (await import("../showSandboxEmailMessage"))
-      .default;
-    const result = await showEmailMessageModule({ message_id: 1 });
-
-    // Restore the original mock
-    jest.dontMock("../../../client");
-    jest.resetModules();
-
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "Error showing sandbox email message:",
-      expect.anything()
-    );
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("Sandbox client is not available");
-    consoleErrorSpy.mockRestore();
+    expect(getSandboxClient).toHaveBeenCalledWith(456);
+    expect(mockShowEmailMessage).toHaveBeenCalledWith(456, 1);
+    expect(result.content[0].text).toContain("Sandbox Email Message Details");
   });
 
   it("should include spam report when include_spam_report is true", async () => {
@@ -209,18 +188,14 @@ describe("showEmailMessage", () => {
         rules: ["RULE_A", "RULE_B"],
       },
     };
-    (sandboxClient as any).testing.messages.getSpamScore.mockResolvedValue(
-      mockSpamReport
-    );
+    mockGetSpamScore.mockResolvedValue(mockSpamReport);
 
     const result = await showEmailMessage({
       message_id: 1,
       include_spam_report: true,
     });
 
-    expect(
-      (sandboxClient as any).testing.messages.getSpamScore
-    ).toHaveBeenCalledWith(123, 1);
+    expect(mockGetSpamScore).toHaveBeenCalledWith(inboxId, 1);
     expect(result.content[0].text).toContain("--- Spam Report ---");
     expect(result.content[0].text).toContain("Spam score: 2.5");
     expect(result.content[0].text).toContain("SpamAssassin report");
@@ -233,18 +208,14 @@ describe("showEmailMessage", () => {
       text_compatibility_score: 100,
       problematic_elements: ["max-width", "style tag"],
     };
-    (sandboxClient as any).testing.messages.getHtmlAnalysis.mockResolvedValue(
-      mockHtmlAnalysis
-    );
+    mockGetHtmlAnalysis.mockResolvedValue(mockHtmlAnalysis);
 
     const result = await showEmailMessage({
       message_id: 1,
       include_html_analysis: true,
     });
 
-    expect(
-      (sandboxClient as any).testing.messages.getHtmlAnalysis
-    ).toHaveBeenCalledWith(123, 1);
+    expect(mockGetHtmlAnalysis).toHaveBeenCalledWith(inboxId, 1);
     expect(result.content[0].text).toContain("--- HTML Analysis ---");
     expect(result.content[0].text).toContain("HTML compatibility score: 85");
     expect(result.content[0].text).toContain("Text compatibility score: 100");
@@ -254,18 +225,12 @@ describe("showEmailMessage", () => {
   it("should not call getSpamScore or getHtmlAnalysis when flags are false", async () => {
     await showEmailMessage({ message_id: 1 });
 
-    expect(
-      (sandboxClient as any).testing.messages.getSpamScore
-    ).not.toHaveBeenCalled();
-    expect(
-      (sandboxClient as any).testing.messages.getHtmlAnalysis
-    ).not.toHaveBeenCalled();
+    expect(mockGetSpamScore).not.toHaveBeenCalled();
+    expect(mockGetHtmlAnalysis).not.toHaveBeenCalled();
   });
 
   it("should handle spam report fetch failure gracefully", async () => {
-    (sandboxClient as any).testing.messages.getSpamScore.mockRejectedValue(
-      new Error("Spam API error")
-    );
+    mockGetSpamScore.mockRejectedValue(new Error("Spam API error"));
     const consoleWarnSpy = jest
       .spyOn(console, "warn")
       .mockImplementation(() => {});
@@ -283,9 +248,7 @@ describe("showEmailMessage", () => {
   });
 
   it("should handle HTML analysis fetch failure gracefully", async () => {
-    (sandboxClient as any).testing.messages.getHtmlAnalysis.mockRejectedValue(
-      new Error("Analyze API error")
-    );
+    mockGetHtmlAnalysis.mockRejectedValue(new Error("Analyze API error"));
     const consoleWarnSpy = jest
       .spyOn(console, "warn")
       .mockImplementation(() => {});
@@ -304,9 +267,7 @@ describe("showEmailMessage", () => {
 
   it("should handle API errors", async () => {
     const mockError = new Error("API Error");
-    (sandboxClient as any).testing.messages.showEmailMessage.mockRejectedValue(
-      mockError
-    );
+    mockShowEmailMessage.mockRejectedValue(mockError);
     const consoleErrorSpy = jest
       .spyOn(console, "error")
       .mockImplementation(() => {});

--- a/src/tools/sandbox/getSandboxMessages.ts
+++ b/src/tools/sandbox/getSandboxMessages.ts
@@ -1,7 +1,8 @@
-import { sandboxClient } from "../../client";
+import { getSandboxClient } from "../../client";
 import { GetMessagesRequest } from "../../types/mailtrap";
 
 async function getMessages({
+  test_inbox_id,
   page,
   last_id,
   search,
@@ -10,25 +11,21 @@ async function getMessages({
   isError?: boolean;
 }> {
   try {
-    const { MAILTRAP_TEST_INBOX_ID } = process.env;
-
-    if (!MAILTRAP_TEST_INBOX_ID) {
+    const inboxIdRaw = test_inbox_id ?? process.env.MAILTRAP_TEST_INBOX_ID;
+    if (inboxIdRaw === undefined || inboxIdRaw === null) {
       throw new Error(
-        "MAILTRAP_TEST_INBOX_ID environment variable is required for sandbox mode"
+        "Provide test_inbox_id or set MAILTRAP_TEST_INBOX_ID environment variable for sandbox mode"
       );
     }
 
-    // Check if sandbox client is available
-    if (!sandboxClient) {
-      throw new Error(
-        "Sandbox client is not available. Please set MAILTRAP_TEST_INBOX_ID environment variable."
-      );
-    }
-
-    const inboxId = Number(MAILTRAP_TEST_INBOX_ID);
+    const inboxId = Number(inboxIdRaw);
     if (Number.isNaN(inboxId)) {
-      throw new Error("MAILTRAP_TEST_INBOX_ID must be a valid number");
+      throw new Error(
+        "test_inbox_id (or MAILTRAP_TEST_INBOX_ID) must be a valid number"
+      );
     }
+
+    const sandboxClient = getSandboxClient(inboxId);
 
     // Get messages from the inbox
     // MessageListOptions supports: page, last_id, and search

--- a/src/tools/sandbox/schemas/getMessages.ts
+++ b/src/tools/sandbox/schemas/getMessages.ts
@@ -1,6 +1,11 @@
 const getMessagesSchema = {
   type: "object",
   properties: {
+    test_inbox_id: {
+      type: "number",
+      description:
+        "Mailtrap test inbox ID. Optional if MAILTRAP_TEST_INBOX_ID env var is set. Use to target a specific inbox.",
+    },
     page: {
       type: "number",
       description: "Page number for pagination",

--- a/src/tools/sandbox/schemas/sendSandboxEmail.ts
+++ b/src/tools/sandbox/schemas/sendSandboxEmail.ts
@@ -1,10 +1,16 @@
 const sendSandboxEmailSchema = {
   type: "object",
   properties: {
+    test_inbox_id: {
+      type: "number",
+      description:
+        "Mailtrap test inbox ID. Optional if MAILTRAP_TEST_INBOX_ID env var is set. Use to target a specific inbox.",
+    },
     from: {
       type: "string",
       format: "email",
-      description: "Email address of the sender",
+      description:
+        "Sender email address. Optional if DEFAULT_FROM_EMAIL env var is set.",
     },
     to: {
       type: "string",
@@ -44,7 +50,7 @@ const sendSandboxEmailSchema = {
       description: "Optional HTML version of the email body",
     },
   },
-  required: ["from", "to", "subject"],
+  required: ["to", "subject"],
   additionalProperties: false,
 };
 

--- a/src/tools/sandbox/schemas/showEmailMessage.ts
+++ b/src/tools/sandbox/schemas/showEmailMessage.ts
@@ -1,6 +1,11 @@
 const showEmailMessageSchema = {
   type: "object",
   properties: {
+    test_inbox_id: {
+      type: "number",
+      description:
+        "Mailtrap test inbox ID. Optional if MAILTRAP_TEST_INBOX_ID env var is set. Use to target a specific inbox.",
+    },
     message_id: {
       type: "number",
       description: "ID of the sandbox email message to retrieve",

--- a/src/tools/sandbox/sendSandboxEmail.ts
+++ b/src/tools/sandbox/sendSandboxEmail.ts
@@ -1,10 +1,9 @@
 import { Address, Mail } from "mailtrap";
-import { sandboxClient } from "../../client";
+import { getSandboxClient } from "../../client";
 import { SendSandboxEmailRequest } from "../../types/mailtrap";
 
-const { DEFAULT_FROM_EMAIL } = process.env;
-
 async function sendSandboxEmail({
+  test_inbox_id,
   from,
   to,
   subject,
@@ -15,11 +14,17 @@ async function sendSandboxEmail({
   html,
 }: SendSandboxEmailRequest): Promise<{ content: any[]; isError?: boolean }> {
   try {
-    const { MAILTRAP_TEST_INBOX_ID } = process.env;
-
-    if (!MAILTRAP_TEST_INBOX_ID) {
+    const inboxIdRaw = test_inbox_id ?? process.env.MAILTRAP_TEST_INBOX_ID;
+    if (inboxIdRaw === undefined || inboxIdRaw === null) {
       throw new Error(
-        "MAILTRAP_TEST_INBOX_ID environment variable is required for sandbox mode"
+        "Provide test_inbox_id or set MAILTRAP_TEST_INBOX_ID environment variable for sandbox mode"
+      );
+    }
+
+    const inboxId = Number(inboxIdRaw);
+    if (Number.isNaN(inboxId)) {
+      throw new Error(
+        "test_inbox_id (or MAILTRAP_TEST_INBOX_ID) must be a valid number"
       );
     }
 
@@ -27,21 +32,14 @@ async function sendSandboxEmail({
       throw new Error("Either HTML or TEXT body is required");
     }
 
-    // Use provided 'from' email or fall back to DEFAULT_FROM_EMAIL
-    const fromEmail = from || DEFAULT_FROM_EMAIL;
-
+    const fromEmail = from ?? process.env.DEFAULT_FROM_EMAIL;
     if (!fromEmail) {
       throw new Error(
-        "No 'from' email provided and no 'DEFAULT_FROM_EMAIL' email set"
+        "Provide 'from' or set DEFAULT_FROM_EMAIL environment variable"
       );
     }
 
-    // Check if sandbox client is available
-    if (!sandboxClient) {
-      throw new Error(
-        "Sandbox client is not available. Please set MAILTRAP_TEST_INBOX_ID environment variable."
-      );
-    }
+    const sandboxClient = getSandboxClient(inboxId);
 
     const fromAddress: Address = {
       email: fromEmail,

--- a/src/tools/sandbox/showSandboxEmailMessage.ts
+++ b/src/tools/sandbox/showSandboxEmailMessage.ts
@@ -1,4 +1,4 @@
-import { sandboxClient } from "../../client";
+import { getSandboxClient } from "../../client";
 import { ShowEmailMessageRequest } from "../../types/mailtrap";
 
 function formatSpamReport(data: unknown): string {
@@ -42,27 +42,27 @@ function formatHtmlAnalysis(data: unknown): string {
 }
 
 async function showEmailMessage({
+  test_inbox_id,
   message_id,
   include_spam_report = false,
   include_html_analysis = false,
 }: ShowEmailMessageRequest): Promise<{ content: any[]; isError?: boolean }> {
   try {
-    const { MAILTRAP_TEST_INBOX_ID } = process.env;
-
-    if (!MAILTRAP_TEST_INBOX_ID) {
+    const inboxIdRaw = test_inbox_id ?? process.env.MAILTRAP_TEST_INBOX_ID;
+    if (inboxIdRaw === undefined || inboxIdRaw === null) {
       throw new Error(
-        "MAILTRAP_TEST_INBOX_ID environment variable is required for sandbox mode"
+        "Provide test_inbox_id or set MAILTRAP_TEST_INBOX_ID environment variable for sandbox mode"
       );
     }
 
-    // Check if sandbox client is available
-    if (!sandboxClient) {
+    const inboxId = Number(inboxIdRaw);
+    if (Number.isNaN(inboxId)) {
       throw new Error(
-        "Sandbox client is not available. Please set MAILTRAP_TEST_INBOX_ID environment variable."
+        "test_inbox_id (or MAILTRAP_TEST_INBOX_ID) must be a valid number"
       );
     }
 
-    const inboxId = Number(MAILTRAP_TEST_INBOX_ID);
+    const sandboxClient = getSandboxClient(inboxId);
 
     // Get message details
     // The showEmailMessage method takes inboxId and messageId

--- a/src/tools/sendEmail/schema.ts
+++ b/src/tools/sendEmail/schema.ts
@@ -1,14 +1,11 @@
-const hasDefaultFromEmail = !!process.env.DEFAULT_FROM_EMAIL;
-
 const sendEmailSchema = {
   type: "object",
   properties: {
     from: {
       type: "string",
       format: "email",
-      description: hasDefaultFromEmail
-        ? "Email address of the sender (optional with default)"
-        : "Email address of the sender",
+      description:
+        "Sender email address. Optional if DEFAULT_FROM_EMAIL env var is set.",
     },
     to: {
       oneOf: [
@@ -65,12 +62,5 @@ const sendEmailSchema = {
   required: ["to", "subject", "category"],
   additionalProperties: false,
 };
-
-if (hasDefaultFromEmail) {
-  // Make from optional when default is available
-  sendEmailSchema.required = sendEmailSchema.required.filter(
-    (field: string) => field !== "from"
-  );
-}
 
 export default sendEmailSchema;

--- a/src/tools/sendEmail/sendEmail.ts
+++ b/src/tools/sendEmail/sendEmail.ts
@@ -28,7 +28,7 @@ async function sendEmail({
 
     if (!fromEmail) {
       throw new Error(
-        "No 'from' email provided and no 'DEFAULT_FROM_EMAIL' email set"
+        "Provide 'from' or set DEFAULT_FROM_EMAIL environment variable"
       );
     }
 

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -46,7 +46,8 @@ export interface DeleteTemplateRequest {
  * The MCP server validates this requirement through runtime checks.
  */
 export interface SendSandboxEmailRequest {
-  from: string;
+  test_inbox_id?: number;
+  from?: string;
   to: string;
   subject: string;
   text?: string;
@@ -57,12 +58,14 @@ export interface SendSandboxEmailRequest {
 }
 
 export interface GetMessagesRequest {
+  test_inbox_id?: number;
   page?: number;
   last_id?: number;
   search?: string;
 }
 
 export interface ShowEmailMessageRequest {
+  test_inbox_id?: number;
   message_id: number;
   /** When true, include spam report (SpamAssassin score and details). Useful for deliverability testing. */
   include_spam_report?: boolean;


### PR DESCRIPTION
## Motivation

I'll be adding sandbox management tool(s) next and it would be good to be able to for example switch to newly created inbox without restarting MCP.

## Changes

- Make DEFAULT_FROM_EMAIL and MAILTRAP_TEST_INBOX_ID config/env params optional so that it's possible to change them in runtime

## Images and GIFs

<img width="622" height="745" alt="Screenshot 2026-03-19 at 09 43 51" src="https://github.com/user-attachments/assets/d50b02ab-b7b1-4489-af3f-64b42fc27615" />
