### PR TITLE
Fix send-email schema; add template-based sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+* Fix **send-email** input schema: `category` is no longer marked as required (it is an optional tracking tag per the Send Email REST API).
+* Make `to` optional for **send-email** and **send-sandbox-email**: at least one of `to`, `cc`, or `bcc` must contain a recipient (validated at runtime). Previously `to` was schema-required, which over-declared the API's actual requirements.
+
 ## [0.3.0] - 2026-03-31
 
 * Support optional **display names** on `from`, `to`, `cc`, and `bcc` for **send-email** and **send-sandbox-email** (addresses can be plain email or `Name <email@example.com>` style). See https://github.com/mailtrap/mailtrap-mcp/pull/72

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 * Fix **send-email** input schema: `category` is no longer marked as required (it is an optional tracking tag per the Send Email REST API).
+* Add **template-based sending** to **send-email** and **send-sandbox-email**: pass `template_uuid` (with optional `template_variables`) to send via a Mailtrap template. Per the Mailtrap API, when `template_uuid` is set, `subject`, `text`, `html`, and `category` must be omitted; this is enforced at runtime. `subject` is no longer in the schema's `required` array since it does not apply to template sends.
 * Make `to` optional for **send-email** and **send-sandbox-email**: at least one of `to`, `cc`, or `bcc` must contain a recipient (validated at runtime). Previously `to` was schema-required, which over-declared the API's actual requirements.
 
 ## [0.3.0] - 2026-03-31

--- a/src/tools/sandbox/__tests__/sendSandboxEmail.test.ts
+++ b/src/tools/sandbox/__tests__/sendSandboxEmail.test.ts
@@ -504,4 +504,106 @@ describe("sendSandboxEmail", () => {
       );
     });
   });
+
+  describe("template sends", () => {
+    it("should send sandbox email using template_uuid", async () => {
+      const result = await sendSandboxEmail({
+        test_inbox_id: inboxId,
+        to: "recipient@example.com",
+        template_uuid: "b81aabcd-1a1e-41cf-91b6-eca0254b3d96",
+        template_variables: { name: "John", order_id: 1234 },
+      });
+
+      expect(mockSend).toHaveBeenCalledWith({
+        from: { email: "default@example.com" },
+        to: [{ email: "recipient@example.com" }],
+        template_uuid: "b81aabcd-1a1e-41cf-91b6-eca0254b3d96",
+        template_variables: { name: "John", order_id: 1234 },
+      });
+
+      expect(result.content[0].text).toContain(
+        "Sandbox email sent successfully to recipient@example.com"
+      );
+      expect(result.isError).toBeUndefined();
+    });
+
+    it("should reject template_uuid combined with subject/text/html/category", async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const result = await sendSandboxEmail({
+        test_inbox_id: inboxId,
+        to: "recipient@example.com",
+        template_uuid: "b81aabcd-1a1e-41cf-91b6-eca0254b3d96",
+        subject: "Should not be here",
+        html: "<p>Body</p>",
+      });
+
+      expect(mockSend).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "Failed to send sandbox email: When 'template_uuid' is set, the following fields must be omitted: subject, html",
+          },
+        ],
+        isError: true,
+      });
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it("should reject template_variables without template_uuid", async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const result = await sendSandboxEmail({
+        test_inbox_id: inboxId,
+        to: "recipient@example.com",
+        subject: "Hello",
+        text: "Body",
+        template_variables: { name: "John" },
+      });
+
+      expect(mockSend).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "Failed to send sandbox email: 'template_variables' can only be used together with 'template_uuid'",
+          },
+        ],
+        isError: true,
+      });
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it("should require subject for inline (non-template) sandbox sends", async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const result = await sendSandboxEmail({
+        test_inbox_id: inboxId,
+        to: "recipient@example.com",
+        text: "Body",
+      });
+
+      expect(mockSend).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "Failed to send sandbox email: 'subject' is required when not using a template",
+          },
+        ],
+        isError: true,
+      });
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
 });

--- a/src/tools/sandbox/__tests__/sendSandboxEmail.test.ts
+++ b/src/tools/sandbox/__tests__/sendSandboxEmail.test.ts
@@ -412,6 +412,26 @@ describe("sendSandboxEmail", () => {
       });
     });
 
+    it("should throw error when no recipients are provided across to/cc/bcc", async () => {
+      const result = await sendSandboxEmail({
+        test_inbox_id: inboxId,
+        from: "default@example.com",
+        subject: "Hello",
+        text: "Body",
+      });
+
+      expect(mockSend).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "Failed to send sandbox email: Provide at least one recipient via 'to', 'cc', or 'bcc'",
+          },
+        ],
+        isError: true,
+      });
+    });
+
     it("should handle client.send failure", async () => {
       const mockError = new Error("Failed to send sandbox email");
       mockSend.mockRejectedValue(mockError);
@@ -431,6 +451,57 @@ describe("sendSandboxEmail", () => {
         ],
         isError: true,
       });
+    });
+  });
+
+  describe("cc/bcc-only sends (no 'to')", () => {
+    it("should send when only cc is provided (no 'to')", async () => {
+      const result = await sendSandboxEmail({
+        test_inbox_id: inboxId,
+        from: "default@example.com",
+        subject: "Hello",
+        text: "Body",
+        cc: ["cc@example.com"],
+      });
+
+      expect(mockSend).toHaveBeenCalledWith({
+        from: { email: "default@example.com" },
+        to: [],
+        subject: "Hello",
+        text: "Body",
+        html: undefined,
+        category: undefined,
+        cc: [{ email: "cc@example.com" }],
+      });
+
+      expect(result.content[0].text).toContain(
+        "Sandbox email sent successfully to cc@example.com"
+      );
+      expect(result.isError).toBeUndefined();
+    });
+
+    it("should send when only bcc is provided (no 'to')", async () => {
+      const result = await sendSandboxEmail({
+        test_inbox_id: inboxId,
+        from: "default@example.com",
+        subject: "Hello",
+        text: "Body",
+        bcc: [{ email: "bcc@example.com", name: "BCC User" }],
+      });
+
+      expect(mockSend).toHaveBeenCalledWith({
+        from: { email: "default@example.com" },
+        to: [],
+        subject: "Hello",
+        text: "Body",
+        html: undefined,
+        category: undefined,
+        bcc: [{ email: "bcc@example.com", name: "BCC User" }],
+      });
+
+      expect(result.content[0].text).toContain(
+        "Sandbox email sent successfully to bcc@example.com"
+      );
     });
   });
 });

--- a/src/tools/sandbox/schemas/sendSandboxEmail.ts
+++ b/src/tools/sandbox/schemas/sendSandboxEmail.ts
@@ -34,7 +34,8 @@ const sendSandboxEmailSchema = {
     },
     subject: {
       type: "string",
-      description: "Email subject line",
+      description:
+        "Email subject line. Required for inline (text/html) sends; must be omitted when `template_uuid` is set.",
     },
     cc: {
       type: "array",
@@ -48,18 +49,32 @@ const sendSandboxEmailSchema = {
     },
     category: {
       type: "string",
-      description: "Optional email category for tracking",
+      description:
+        "Optional email category for tracking. Must be omitted when `template_uuid` is set.",
     },
     text: {
       type: "string",
-      description: "Email body text",
+      description:
+        "Email body text. Required (alongside or instead of `html`) for inline sends; must be omitted when `template_uuid` is set.",
     },
     html: {
       type: "string",
-      description: "Optional HTML version of the email body",
+      description:
+        "Optional HTML version of the email body. Must be omitted when `template_uuid` is set.",
+    },
+    template_uuid: {
+      type: "string",
+      description:
+        "Use a Mailtrap email template instead of inline content. When set, `subject`, `text`, `html`, and `category` must be omitted (per Mailtrap API).",
+    },
+    template_variables: {
+      type: "object",
+      additionalProperties: true,
+      description:
+        "Variables substituted into the template referenced by `template_uuid`. Only allowed together with `template_uuid`; rejected otherwise.",
     },
   },
-  required: ["subject"],
+  required: [],
   additionalProperties: false,
 };
 

--- a/src/tools/sandbox/schemas/sendSandboxEmail.ts
+++ b/src/tools/sandbox/schemas/sendSandboxEmail.ts
@@ -30,7 +30,7 @@ const sendSandboxEmailSchema = {
         },
       ],
       description:
-        "Recipients: comma-separated string, or an array of addresses with optional display names.",
+        "Recipients: comma-separated string, or an array of addresses with optional display names. Optional if `cc` or `bcc` is provided; at least one of `to`/`cc`/`bcc` must contain a recipient.",
     },
     subject: {
       type: "string",
@@ -59,7 +59,7 @@ const sendSandboxEmailSchema = {
       description: "Optional HTML version of the email body",
     },
   },
-  required: ["to", "subject"],
+  required: ["subject"],
   additionalProperties: false,
 };
 

--- a/src/tools/sandbox/sendSandboxEmail.ts
+++ b/src/tools/sandbox/sendSandboxEmail.ts
@@ -41,7 +41,15 @@ async function sendSandboxEmail({
 
     const sandboxClient = getSandboxClient(inboxId);
 
-    const toAddresses = parseSandboxTo(to);
+    const toAddresses = to !== undefined ? parseSandboxTo(to) : [];
+    const ccAddresses = cc && cc.length > 0 ? normalizeAddressList(cc) : [];
+    const bccAddresses = bcc && bcc.length > 0 ? normalizeAddressList(bcc) : [];
+
+    if (toAddresses.length + ccAddresses.length + bccAddresses.length === 0) {
+      throw new Error(
+        "Provide at least one recipient via 'to', 'cc', or 'bcc'"
+      );
+    }
 
     const emailData: Mail = {
       from: fromAddress,
@@ -52,28 +60,26 @@ async function sendSandboxEmail({
       category,
     };
 
-    if (cc && cc.length > 0) {
-      const ccAddresses = normalizeAddressList(cc);
-      if (ccAddresses.length > 0) {
-        emailData.cc = ccAddresses;
-      }
+    if (ccAddresses.length > 0) {
+      emailData.cc = ccAddresses;
     }
-    if (bcc && bcc.length > 0) {
-      const bccAddresses = normalizeAddressList(bcc);
-      if (bccAddresses.length > 0) {
-        emailData.bcc = bccAddresses;
-      }
+    if (bccAddresses.length > 0) {
+      emailData.bcc = bccAddresses;
     }
 
     const response = await sandboxClient.send(emailData);
+
+    const recipientSummary = (
+      toAddresses.length > 0 ? toAddresses : [...ccAddresses, ...bccAddresses]
+    )
+      .map((addr) => addr.email)
+      .join(", ");
 
     return {
       content: [
         {
           type: "text",
-          text: `Sandbox email sent successfully to ${toAddresses
-            .map((addr) => addr.email)
-            .join(", ")}.\nMessage IDs: ${response.message_ids.join(
+          text: `Sandbox email sent successfully to ${recipientSummary}.\nMessage IDs: ${response.message_ids.join(
             ", "
           )}\nStatus: ${response.success ? "Success" : "Failed"}`,
         },

--- a/src/tools/sandbox/sendSandboxEmail.ts
+++ b/src/tools/sandbox/sendSandboxEmail.ts
@@ -17,6 +17,8 @@ async function sendSandboxEmail({
   bcc,
   category,
   html,
+  template_uuid,
+  template_variables,
 }: SendSandboxEmailRequest): Promise<{ content: any[]; isError?: boolean }> {
   try {
     const inboxIdRaw = test_inbox_id ?? process.env.MAILTRAP_TEST_INBOX_ID;
@@ -33,8 +35,31 @@ async function sendSandboxEmail({
       );
     }
 
-    if (!html && !text) {
-      throw new Error("Either HTML or TEXT body is required");
+    if (template_uuid) {
+      const forbidden = [
+        ["subject", subject],
+        ["text", text],
+        ["html", html],
+        ["category", category],
+      ].filter(([, value]) => value !== undefined && value !== "");
+      if (forbidden.length > 0) {
+        const fields = forbidden.map(([name]) => name).join(", ");
+        throw new Error(
+          `When 'template_uuid' is set, the following fields must be omitted: ${fields}`
+        );
+      }
+    } else {
+      if (!subject) {
+        throw new Error("'subject' is required when not using a template");
+      }
+      if (!html && !text) {
+        throw new Error("Either HTML or TEXT body is required");
+      }
+      if (template_variables !== undefined) {
+        throw new Error(
+          "'template_variables' can only be used together with 'template_uuid'"
+        );
+      }
     }
 
     const fromAddress = buildFromAddress(from, process.env.DEFAULT_FROM_EMAIL);
@@ -51,14 +76,21 @@ async function sendSandboxEmail({
       );
     }
 
-    const emailData: Mail = {
-      from: fromAddress,
-      to: toAddresses,
-      subject,
-      text,
-      html,
-      category,
-    };
+    const emailData: Mail = template_uuid
+      ? {
+          from: fromAddress,
+          to: toAddresses,
+          template_uuid,
+          template_variables,
+        }
+      : {
+          from: fromAddress,
+          to: toAddresses,
+          subject: subject as string,
+          text,
+          html,
+          category,
+        };
 
     if (ccAddresses.length > 0) {
       emailData.cc = ccAddresses;

--- a/src/tools/sendEmail/__tests__/sendEmail.test.ts
+++ b/src/tools/sendEmail/__tests__/sendEmail.test.ts
@@ -327,7 +327,7 @@ describe("sendEmail", () => {
       });
     });
 
-    it("should throw error when empty array is provided for 'to' field", async () => {
+    it("should throw error when no recipients are provided across to/cc/bcc", async () => {
       const result = await sendEmail({
         ...mockEmailData,
         to: [],
@@ -338,14 +338,14 @@ describe("sendEmail", () => {
         content: [
           {
             type: "text",
-            text: "Failed to send email: No valid recipients provided in 'to' field after normalization",
+            text: "Failed to send email: Provide at least one recipient via 'to', 'cc', or 'bcc'",
           },
         ],
         isError: true,
       });
     });
 
-    it("should throw error when empty string is provided for 'to' field", async () => {
+    it("should throw error when 'to' is empty string and no cc/bcc are provided", async () => {
       const result = await sendEmail({
         ...mockEmailData,
         to: "",
@@ -356,7 +356,7 @@ describe("sendEmail", () => {
         content: [
           {
             type: "text",
-            text: "Failed to send email: No valid recipients provided in 'to' field after normalization",
+            text: "Failed to send email: Provide at least one recipient via 'to', 'cc', or 'bcc'",
           },
         ],
         isError: true,
@@ -402,6 +402,57 @@ describe("sendEmail", () => {
         ],
         isError: true,
       });
+    });
+  });
+
+  describe("cc/bcc-only sends (no 'to')", () => {
+    it("should send when only cc is provided (no 'to')", async () => {
+      const result = await sendEmail({
+        subject: "Test Subject",
+        text: "Test email body",
+        cc: ["cc@example.com"],
+      });
+
+      expect(mockClient.send).toHaveBeenCalledWith({
+        from: { email: "default@example.com" },
+        to: [],
+        subject: "Test Subject",
+        text: "Test email body",
+        html: undefined,
+        category: undefined,
+        cc: [{ email: "cc@example.com" }],
+      });
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: `Email sent successfully to cc@example.com.\nMessage IDs: ${mockResponse.message_ids}\nStatus: Success`,
+          },
+        ],
+      });
+    });
+
+    it("should send when only bcc is provided (no 'to')", async () => {
+      const result = await sendEmail({
+        subject: "Test Subject",
+        text: "Test email body",
+        bcc: [{ email: "bcc@example.com", name: "BCC User" }],
+      });
+
+      expect(mockClient.send).toHaveBeenCalledWith({
+        from: { email: "default@example.com" },
+        to: [],
+        subject: "Test Subject",
+        text: "Test email body",
+        html: undefined,
+        category: undefined,
+        bcc: [{ email: "bcc@example.com", name: "BCC User" }],
+      });
+
+      expect(result.content[0].text).toContain(
+        "Email sent successfully to bcc@example.com"
+      );
     });
   });
 });

--- a/src/tools/sendEmail/__tests__/sendEmail.test.ts
+++ b/src/tools/sendEmail/__tests__/sendEmail.test.ts
@@ -455,4 +455,121 @@ describe("sendEmail", () => {
       );
     });
   });
+
+  describe("template sends", () => {
+    it("should send email using template_uuid", async () => {
+      const result = await sendEmail({
+        to: "recipient@example.com",
+        template_uuid: "b81aabcd-1a1e-41cf-91b6-eca0254b3d96",
+        template_variables: { name: "John", order_id: 1234 },
+      });
+
+      expect(mockClient.send).toHaveBeenCalledWith({
+        from: { email: "default@example.com" },
+        to: [{ email: "recipient@example.com" }],
+        template_uuid: "b81aabcd-1a1e-41cf-91b6-eca0254b3d96",
+        template_variables: { name: "John", order_id: 1234 },
+      });
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: `Email sent successfully to recipient@example.com.\nMessage IDs: ${mockResponse.message_ids}\nStatus: Success`,
+          },
+        ],
+      });
+    });
+
+    it("should send template-based email without template_variables", async () => {
+      await sendEmail({
+        to: "recipient@example.com",
+        template_uuid: "b81aabcd-1a1e-41cf-91b6-eca0254b3d96",
+      });
+
+      expect(mockClient.send).toHaveBeenCalledWith({
+        from: { email: "default@example.com" },
+        to: [{ email: "recipient@example.com" }],
+        template_uuid: "b81aabcd-1a1e-41cf-91b6-eca0254b3d96",
+        template_variables: undefined,
+      });
+    });
+
+    it("should pass cc and bcc through with template sends", async () => {
+      await sendEmail({
+        to: "recipient@example.com",
+        template_uuid: "b81aabcd-1a1e-41cf-91b6-eca0254b3d96",
+        cc: ["cc@example.com"],
+        bcc: [{ email: "bcc@example.com", name: "BCC User" }],
+      });
+
+      expect(mockClient.send).toHaveBeenCalledWith({
+        from: { email: "default@example.com" },
+        to: [{ email: "recipient@example.com" }],
+        template_uuid: "b81aabcd-1a1e-41cf-91b6-eca0254b3d96",
+        template_variables: undefined,
+        cc: [{ email: "cc@example.com" }],
+        bcc: [{ email: "bcc@example.com", name: "BCC User" }],
+      });
+    });
+
+    it("should reject template_uuid combined with subject/text/html/category", async () => {
+      const result = await sendEmail({
+        to: "recipient@example.com",
+        template_uuid: "b81aabcd-1a1e-41cf-91b6-eca0254b3d96",
+        subject: "Should not be here",
+        text: "Body",
+        category: "promo",
+      });
+
+      expect(mockClient.send).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "Failed to send email: When 'template_uuid' is set, the following fields must be omitted: subject, text, category",
+          },
+        ],
+        isError: true,
+      });
+    });
+
+    it("should reject template_variables without template_uuid", async () => {
+      const result = await sendEmail({
+        to: "recipient@example.com",
+        subject: "Hello",
+        text: "Body",
+        template_variables: { name: "John" },
+      });
+
+      expect(mockClient.send).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "Failed to send email: 'template_variables' can only be used together with 'template_uuid'",
+          },
+        ],
+        isError: true,
+      });
+    });
+
+    it("should require subject for inline (non-template) sends", async () => {
+      const result = await sendEmail({
+        to: "recipient@example.com",
+        text: "Body",
+      });
+
+      expect(mockClient.send).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: "Failed to send email: 'subject' is required when not using a template",
+          },
+        ],
+        isError: true,
+      });
+    });
+  });
 });

--- a/src/tools/sendEmail/schema.ts
+++ b/src/tools/sendEmail/schema.ts
@@ -22,7 +22,8 @@ const sendEmailSchema = {
     },
     subject: {
       type: "string",
-      description: "Email subject line",
+      description:
+        "Email subject line. Required for inline (text/html) sends; must be omitted when `template_uuid` is set.",
     },
     cc: {
       type: "array",
@@ -36,18 +37,32 @@ const sendEmailSchema = {
     },
     category: {
       type: "string",
-      description: "Optional email category for tracking",
+      description:
+        "Optional email category for tracking. Must be omitted when `template_uuid` is set.",
     },
     text: {
       type: "string",
-      description: "Email body text",
+      description:
+        "Email body text. Required (alongside or instead of `html`) for inline sends; must be omitted when `template_uuid` is set.",
     },
     html: {
       type: "string",
-      description: "Optional HTML version of the email body",
+      description:
+        "Optional HTML version of the email body. Must be omitted when `template_uuid` is set.",
+    },
+    template_uuid: {
+      type: "string",
+      description:
+        "Use a Mailtrap email template instead of inline content. When set, `subject`, `text`, `html`, and `category` must be omitted (per Mailtrap API).",
+    },
+    template_variables: {
+      type: "object",
+      additionalProperties: true,
+      description:
+        "Variables substituted into the template referenced by `template_uuid`. Only allowed together with `template_uuid`; rejected otherwise.",
     },
   },
-  required: ["subject"],
+  required: [],
   additionalProperties: false,
 };
 

--- a/src/tools/sendEmail/schema.ts
+++ b/src/tools/sendEmail/schema.ts
@@ -18,7 +18,7 @@ const sendEmailSchema = {
         },
       ],
       description:
-        "Recipient(s): one address (string or `{ email, name? }`) or a non-empty array of those.",
+        "Recipient(s): one address (string or `{ email, name? }`) or a non-empty array of those. Optional if `cc` or `bcc` is provided; at least one of `to`/`cc`/`bcc` must contain a recipient.",
     },
     subject: {
       type: "string",
@@ -36,7 +36,7 @@ const sendEmailSchema = {
     },
     category: {
       type: "string",
-      description: "Email category for tracking",
+      description: "Optional email category for tracking",
     },
     text: {
       type: "string",
@@ -47,7 +47,7 @@ const sendEmailSchema = {
       description: "Optional HTML version of the email body",
     },
   },
-  required: ["to", "subject", "category"],
+  required: ["subject"],
   additionalProperties: false,
 };
 

--- a/src/tools/sendEmail/sendEmail.ts
+++ b/src/tools/sendEmail/sendEmail.ts
@@ -19,14 +19,39 @@ async function sendEmail({
   bcc,
   category,
   html,
+  template_uuid,
+  template_variables,
 }: SendMailToolRequest): Promise<{ content: any[]; isError?: boolean }> {
   try {
     const mailtrap = requireClient("sending email", {
       requireAccountId: false,
     });
 
-    if (!html && !text) {
-      throw new Error("Either HTML or TEXT body is required");
+    if (template_uuid) {
+      const forbidden = [
+        ["subject", subject],
+        ["text", text],
+        ["html", html],
+        ["category", category],
+      ].filter(([, value]) => value !== undefined && value !== "");
+      if (forbidden.length > 0) {
+        const fields = forbidden.map(([name]) => name).join(", ");
+        throw new Error(
+          `When 'template_uuid' is set, the following fields must be omitted: ${fields}`
+        );
+      }
+    } else {
+      if (!subject) {
+        throw new Error("'subject' is required when not using a template");
+      }
+      if (!html && !text) {
+        throw new Error("Either HTML or TEXT body is required");
+      }
+      if (template_variables !== undefined) {
+        throw new Error(
+          "'template_variables' can only be used together with 'template_uuid'"
+        );
+      }
     }
 
     const fromAddress = buildFromAddress(from, DEFAULT_FROM_EMAIL);
@@ -41,14 +66,21 @@ async function sendEmail({
       );
     }
 
-    const emailData: Mail = {
-      from: fromAddress,
-      to: toAddresses,
-      subject,
-      text,
-      html,
-      category,
-    };
+    const emailData: Mail = template_uuid
+      ? {
+          from: fromAddress,
+          to: toAddresses,
+          template_uuid,
+          template_variables,
+        }
+      : {
+          from: fromAddress,
+          to: toAddresses,
+          subject: subject as string,
+          text,
+          html,
+          category,
+        };
 
     if (ccAddresses.length > 0) {
       emailData.cc = ccAddresses;

--- a/src/tools/sendEmail/sendEmail.ts
+++ b/src/tools/sendEmail/sendEmail.ts
@@ -31,11 +31,13 @@ async function sendEmail({
 
     const fromAddress = buildFromAddress(from, DEFAULT_FROM_EMAIL);
 
-    const toAddresses = normalizeToRecipients(to);
+    const toAddresses = to !== undefined ? normalizeToRecipients(to) : [];
+    const ccAddresses = cc && cc.length > 0 ? normalizeAddressList(cc) : [];
+    const bccAddresses = bcc && bcc.length > 0 ? normalizeAddressList(bcc) : [];
 
-    if (toAddresses.length === 0) {
+    if (toAddresses.length + ccAddresses.length + bccAddresses.length === 0) {
       throw new Error(
-        "No valid recipients provided in 'to' field after normalization"
+        "Provide at least one recipient via 'to', 'cc', or 'bcc'"
       );
     }
 
@@ -48,30 +50,28 @@ async function sendEmail({
       category,
     };
 
-    if (cc && cc.length > 0) {
-      const ccAddresses = normalizeAddressList(cc);
-      if (ccAddresses.length > 0) {
-        emailData.cc = ccAddresses;
-      }
+    if (ccAddresses.length > 0) {
+      emailData.cc = ccAddresses;
     }
-    if (bcc && bcc.length > 0) {
-      const bccAddresses = normalizeAddressList(bcc);
-      if (bccAddresses.length > 0) {
-        emailData.bcc = bccAddresses;
-      }
+    if (bccAddresses.length > 0) {
+      emailData.bcc = bccAddresses;
     }
 
     const response = await mailtrap.send(emailData);
+
+    const recipientSummary = (
+      toAddresses.length > 0 ? toAddresses : [...ccAddresses, ...bccAddresses]
+    )
+      .map((addr) => addr.email)
+      .join(", ");
 
     return {
       content: [
         {
           type: "text",
-          text: `Email sent successfully to ${toAddresses
-            .map((addr) => addr.email)
-            .join(", ")}.\nMessage IDs: ${response.message_ids}\nStatus: ${
-            response.success ? "Success" : "Failed"
-          }`,
+          text: `Email sent successfully to ${recipientSummary}.\nMessage IDs: ${
+            response.message_ids
+          }\nStatus: ${response.success ? "Success" : "Failed"}`,
         },
       ],
     };

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -5,13 +5,13 @@ export type MailtrapAddressParam = string | { email: string; name?: string };
 
 export interface SendMailToolRequest {
   from?: MailtrapAddressParam;
-  to: MailtrapAddressParam | MailtrapAddressParam[];
+  to?: MailtrapAddressParam | MailtrapAddressParam[];
   subject: string;
   text?: string;
   html?: string;
   cc?: MailtrapAddressParam[];
   bcc?: MailtrapAddressParam[];
-  category: string;
+  category?: string;
 }
 
 export interface CreateTemplateRequest {
@@ -39,7 +39,8 @@ export interface DeleteTemplateRequest {
  * Request interface for sending sandbox emails.
  *
  * @property from - Sender as email string or `{ email, name? }`
- * @property to - Comma-separated emails (legacy), or an array of strings / `{ email, name? }` objects
+ * @property to - Comma-separated emails (legacy), or an array of strings / `{ email, name? }` objects.
+ *                Optional if `cc` or `bcc` is provided; at least one of `to`/`cc`/`bcc` must contain a recipient.
  * @property subject - Email subject line
  * @property text - Email body text (optional, but either text or html must be provided)
  * @property html - HTML version of the email body (optional, but either text or html must be provided)
@@ -53,7 +54,7 @@ export interface DeleteTemplateRequest {
 export interface SendSandboxEmailRequest {
   test_inbox_id?: number;
   from?: MailtrapAddressParam;
-  to: string | MailtrapAddressParam[];
+  to?: string | MailtrapAddressParam[];
   subject: string;
   text?: string;
   html?: string;

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -3,15 +3,40 @@
  */
 export type MailtrapAddressParam = string | { email: string; name?: string };
 
+/**
+ * Values that can appear inside `template_variables`. Mirrors the Mailtrap SDK's
+ * `TemplateValue` (string | number | boolean | nested array/object), without depending
+ * on SDK internals.
+ */
+export type TemplateVariableValue =
+  | string
+  | number
+  | boolean
+  | TemplateVariableValue[]
+  | { [key: string]: TemplateVariableValue };
+
+/**
+ * Request interface for sending transactional emails.
+ *
+ * The Mailtrap Send Email API accepts two mutually exclusive request shapes:
+ *
+ *  - **Inline content**: `subject` + (`text` or `html`), with optional `category`.
+ *  - **Template**: `template_uuid` (and optional `template_variables`); per the API,
+ *    `subject`, `text`, `html`, and `category` must NOT be sent in this case.
+ *
+ * Mutual exclusion is enforced at runtime in the handler.
+ */
 export interface SendMailToolRequest {
   from?: MailtrapAddressParam;
   to?: MailtrapAddressParam | MailtrapAddressParam[];
-  subject: string;
+  subject?: string;
   text?: string;
   html?: string;
   cc?: MailtrapAddressParam[];
   bcc?: MailtrapAddressParam[];
   category?: string;
+  template_uuid?: string;
+  template_variables?: Record<string, TemplateVariableValue>;
 }
 
 export interface CreateTemplateRequest {
@@ -38,29 +63,22 @@ export interface DeleteTemplateRequest {
 /**
  * Request interface for sending sandbox emails.
  *
- * @property from - Sender as email string or `{ email, name? }`
- * @property to - Comma-separated emails (legacy), or an array of strings / `{ email, name? }` objects.
- *                Optional if `cc` or `bcc` is provided; at least one of `to`/`cc`/`bcc` must contain a recipient.
- * @property subject - Email subject line
- * @property text - Email body text (optional, but either text or html must be provided)
- * @property html - HTML version of the email body (optional, but either text or html must be provided)
- * @property cc - Optional CC recipients
- * @property bcc - Optional BCC recipients
- * @property category - Optional email category for tracking
- *
- * Note: At least one of `text` or `html` must be provided at runtime.
- * The MCP server validates this requirement through runtime checks.
+ * Same two mutually-exclusive request shapes as the production send (see
+ * `SendMailToolRequest`): either inline content (`subject` + `text`/`html`) or
+ * template (`template_uuid`). Mutual exclusion is enforced at runtime.
  */
 export interface SendSandboxEmailRequest {
   test_inbox_id?: number;
   from?: MailtrapAddressParam;
   to?: string | MailtrapAddressParam[];
-  subject: string;
+  subject?: string;
   text?: string;
   html?: string;
   cc?: MailtrapAddressParam[];
   bcc?: MailtrapAddressParam[];
   category?: string;
+  template_uuid?: string;
+  template_variables?: Record<string, TemplateVariableValue>;
 }
 
 export interface GetMessagesRequest {

--- a/src/utils/mailtrapAddresses.ts
+++ b/src/utils/mailtrapAddresses.ts
@@ -57,7 +57,11 @@ export function normalizeToRecipients(
   return normalizeAddressList(list);
 }
 
-/** Sandbox `to` as comma-separated string (plain emails) or an array of address params. */
+/**
+ * Sandbox `to` as comma-separated string (plain emails) or an array of address params.
+ * Returns an empty array if no valid recipients are present; callers are responsible
+ * for validating that the combined to/cc/bcc has at least one recipient.
+ */
 export function parseSandboxTo(to: string | MailtrapAddressParam[]): Address[] {
   if (typeof to === "string") {
     const toEmails = to
@@ -65,14 +69,7 @@ export function parseSandboxTo(to: string | MailtrapAddressParam[]): Address[] {
       .map((email) => email.trim())
       .filter((email) => email.length > 0)
       .filter((email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email));
-    if (toEmails.length === 0) {
-      throw new Error("No valid email addresses provided in 'to' field");
-    }
     return toEmails.map((email) => ({ email }));
   }
-  const addresses = normalizeAddressList(to);
-  if (addresses.length === 0) {
-    throw new Error("No valid recipients in 'to' field");
-  }
-  return addresses;
+  return normalizeAddressList(to);
 }


### PR DESCRIPTION
## Summary

Two related changes to `send-email` and `send-sandbox-email` MCP tools, on top of the customer-reported schema bug. Tracked in [MT-22001](https://railsware.atlassian.net/browse/MT-22001).

- **`80c5c77` — fix: align input schema with REST API requirements**
  - `category` and `to` removed from schema `required` arrays in both tools.
  - Runtime check: at least one of `to` / `cc` / `bcc` must contain a recipient (matches the API's actual rule).
  - `parseSandboxTo` no longer throws on empty input — combined check in handler is the single source of truth.

- **`eea569e` — feat: template-based sending**
  - New `template_uuid` and `template_variables` parameters on `send-email` and `send-sandbox-email`.
  - Per the API, when `template_uuid` is set, `subject` / `text` / `html` / `category` must be omitted — enforced at runtime with a clear error.
  - Also rejects `template_variables` without `template_uuid`.
  - `subject` removed from schema `required` (does not apply to template sends).

## Background

A customer reported that the schema was out of sync with the [Mailtrap Send Email API](https://api-docs.mailtrap.io/):

- `category` was marked required (it's an optional tracking tag).
- `to` was marked required (per API, at least one of `to`/`cc`/`bcc` is required).
- The MCP did not expose `template_uuid` at all — callers couldn't send via a Mailtrap template.

## Test plan

Automated:
- [x] `npm test` — 186 / 186 jest tests pass (+ 10 new tests for cc/bcc-only sends and template paths).
- [x] `npm run lint` — eslint + tsc clean.

Manual against Mailtrap (suggested for QA):
- [ ] Inline send: only `to`, only `cc`, only `bcc`, all combined.
- [ ] Inline send: omit `category` (no longer schema-required).
- [ ] Template send: `template_uuid` only; with `template_variables`; with `cc`/`bcc`.
- [ ] Negative: `template_uuid` + `subject`/`text`/`html`/`category` → rejected with clear message.
- [ ] Negative: `template_variables` without `template_uuid` → rejected.
- [ ] Negative: no recipient at all → rejected with the combined-recipient error.

[MT-22001]: https://railsware.atlassian.net/browse/MT-22001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template-based email sending with template variables; template mode disallows inline subject/text/html/category.
  * Recipient handling: `to` is optional; at least one recipient must exist across `to`, `cc`, or `bcc`.

* **Documentation**
  * Clarified schema descriptions for template vs inline sends and recipient rules.

* **Tests**
  * Added coverage for template sends, recipient validation (including cc/bcc-only cases), and related error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->