### PR TITLE
feat(send-email): add attachments[] with inline + downloadable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,65 @@ Sends a transactional email through Mailtrap.
 - `cc` (optional): Array of CC recipient email addresses
 - `bcc` (optional): Array of BCC recipient email addresses
 - `category` (required): Email category for tracking and analytics
+- `attachments` (optional): Array of attachment objects — see [Attachments](#attachments) below.
+
+### Attachments
+
+`send-email` and `send-sandbox-email` accept an optional `attachments` array. Each entry uses Mailtrap's wire-format field names:
+
+| Field         | Required             | Description                                                                                                              |
+| ------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `content`     | yes                  | Base64-encoded file content (no whitespace, standard padding). Files are never read from disk by this tool.              |
+| `filename`    | yes                  | Filename shown to the recipient.                                                                                         |
+| `type`        | no                   | MIME type, e.g. `image/png`, `application/pdf`. Defaults to `application/octet-stream`.                                  |
+| `disposition` | no                   | `"attachment"` (default) for a downloadable file. `"inline"` to embed in HTML — requires `content_id`.                   |
+| `content_id`  | yes (when `inline`)  | CID referenced from the HTML body as `<img src="cid:{content_id}">`. Letters, digits, `.`, `_`, `-` only.                |
+
+**Example — inline image:**
+
+```jsonc
+{
+  "to": "user@example.com",
+  "subject": "Logo embed",
+  "html": "<p>Branded header:</p><img src=\"cid:logo\"><p>...</p>",
+  "category": "marketing",
+  "attachments": [
+    {
+      "content": "<base64 of logo.png>",
+      "filename": "logo.png",
+      "type": "image/png",
+      "disposition": "inline",
+      "content_id": "logo"
+    }
+  ]
+}
+```
+
+**Example — downloadable PDF:**
+
+```jsonc
+{
+  "to": "user@example.com",
+  "subject": "Invoice",
+  "text": "Your invoice is attached.",
+  "category": "billing",
+  "attachments": [
+    {
+      "content": "<base64 of invoice.pdf>",
+      "filename": "invoice-2026-001.pdf",
+      "type": "application/pdf"
+    }
+  ]
+}
+```
+
+**Safety limits**
+
+- Per-attachment cap: **10 MB** (decoded). Override with `MAILTRAP_MAX_ATTACHMENT_SIZE_BYTES`.
+- Total across all attachments: **15 MB** (decoded). Override with `MAILTRAP_MAX_ATTACHMENTS_TOTAL_BYTES`. Mailtrap's hard API ceiling is ~20 MB per message after base64 encoding.
+- Executable filename extensions are rejected by default (`.exe`, `.bat`, `.cmd`, `.com`, `.scr`, `.pif`, `.lnk`, `.vbs`, `.vbe`, `.js`, `.jse`, `.wsf`, `.wsh`, `.ps1`, `.msi`, `.reg`, `.hta`, `.scf`, `.jar`, `.dll`, `.sh`). Override with `MAILTRAP_ATTACHMENT_BLOCKED_EXTENSIONS` (comma-separated, lowercase, with or without leading dots).
+- Blocked MIME types: `application/x-msdownload`, `application/x-msdos-program`, `application/x-exe`, `application/x-executable`, `application/x-shellscript`, `application/x-sh`, `text/x-shellscript`. Override with `MAILTRAP_ATTACHMENT_BLOCKED_MIME_TYPES`.
+- Filenames are never resolved to paths — the tool only handles in-memory base64 content. To attach a file from disk, read it via a separate filesystem MCP and pass the encoded bytes.
 
 ### list-email-logs
 
@@ -322,6 +381,7 @@ Sends an email to your Mailtrap test inbox for development and testing purposes.
 - `cc` (optional): Array of CC recipient email addresses
 - `bcc` (optional): Array of BCC recipient email addresses
 - `category` (optional): Email category for tracking
+- `attachments` (optional): Array of attachment objects — see [Attachments](#attachments) above.
 
 > [!NOTE]
 > For sandbox tools, provide `test_inbox_id` in the tool call or set the `MAILTRAP_TEST_INBOX_ID` environment variable. You can switch between inboxes per call by passing `test_inbox_id`.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "mailtrap-mcpb",
   "display_name": "Mailtrap",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Send emails and manage templates using Mailtrap",
   "long_description": "**[Mailtrap.io](https://mailtrap.io)** is a comprehensive email platform that helps developers and teams test, debug, and deliver emails safely. It provides both email testing (sandbox) and email delivery services. \n This MCP (Model Context Protocol) server provides AI assistants with the ability to: \n - **Send emails** via Mailtrap's delivery API \n - **Test emails** using Mailtrap's sandbox environment \n - **Manage email templates** (create, update, delete, list).",
   "author": {
@@ -34,7 +34,7 @@
   "tools": [
     {
       "name": "send-email",
-      "description": "Send emails via Mailtrap's delivery API with support for HTML/text content and multiple recipients."
+      "description": "Send emails via Mailtrap's delivery API with support for HTML/text content, multiple recipients, and inline or downloadable attachments."
     },
     {
       "name": "create-template",
@@ -54,7 +54,7 @@
     },
     {
       "name": "send-sandbox-email",
-      "description": "Send test emails to Mailtrap's sandbox environment without delivering to real recipients."
+      "description": "Send test emails to Mailtrap's sandbox environment without delivering to real recipients. Supports inline and downloadable attachments."
     },
     {
       "name": "get-sandbox-messages",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-mailtrap",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-mailtrap",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.2",
@@ -5327,9 +5327,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-mailtrap",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Official MCP Server for Mailtrap",
   "license": "MIT",
   "author": "Railsware Products Studio LLC",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,5 @@
 export default {
   MCP_SERVER_NAME: "mailtrap-mcp-server",
-  MCP_SERVER_VERSION: "0.3.0",
+  MCP_SERVER_VERSION: "0.3.1",
   USER_AGENT: "mailtrap-mcp (https://github.com/mailtrap/mailtrap-mcp)",
 };

--- a/src/tools/sandbox/__tests__/sendSandboxEmail.test.ts
+++ b/src/tools/sandbox/__tests__/sendSandboxEmail.test.ts
@@ -354,6 +354,76 @@ describe("sendSandboxEmail", () => {
     });
   });
 
+  describe("attachments", () => {
+    const TINY_B64 = "aGVsbG8gd29ybGQ=";
+
+    it("forwards a regular attachment to the SDK in Nodemailer shape", async () => {
+      await sendSandboxEmail({
+        ...mockEmailData,
+        attachments: [
+          {
+            content: TINY_B64,
+            filename: "report.pdf",
+            type: "application/pdf",
+          },
+        ],
+      });
+
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: [
+            {
+              content: TINY_B64,
+              filename: "report.pdf",
+              contentType: "application/pdf",
+            },
+          ],
+        })
+      );
+    });
+
+    it("forwards an inline image with cid", async () => {
+      await sendSandboxEmail({
+        ...mockEmailData,
+        html: '<p><img src="cid:logo"></p>',
+        attachments: [
+          {
+            content: TINY_B64,
+            filename: "logo.png",
+            type: "image/png",
+            disposition: "inline",
+            content_id: "logo",
+          },
+        ],
+      });
+
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: [
+            {
+              content: TINY_B64,
+              filename: "logo.png",
+              contentType: "image/png",
+              contentDisposition: "inline",
+              cid: "logo",
+            },
+          ],
+        })
+      );
+    });
+
+    it("returns isError when an attachment fails validation", async () => {
+      const result = await sendSandboxEmail({
+        ...mockEmailData,
+        attachments: [{ content: TINY_B64, filename: "payload.exe" }],
+      });
+
+      expect(mockSend).not.toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toMatch(/blocked/);
+    });
+  });
+
   describe("errors handling", () => {
     let consoleErrorSpy: jest.SpyInstance;
 

--- a/src/tools/sandbox/schemas/sendSandboxEmail.ts
+++ b/src/tools/sandbox/schemas/sendSandboxEmail.ts
@@ -1,4 +1,5 @@
 import mailtrapAddressParamSchema from "../../schemas/mailtrapAddressParam";
+import attachmentParamSchema from "../../schemas/attachmentParam";
 
 const sendSandboxEmailSchema = {
   type: "object",
@@ -57,6 +58,17 @@ const sendSandboxEmailSchema = {
     html: {
       type: "string",
       description: "Optional HTML version of the email body",
+    },
+    attachments: {
+      type: "array",
+      minItems: 1,
+      items: attachmentParamSchema,
+      description:
+        "Optional attachments. Each entry must include base64 `content` and `filename`. " +
+        "Set `disposition: 'inline'` plus `content_id` to embed images referenced from HTML " +
+        'as `<img src="cid:{content_id}">`; otherwise the file is delivered as a download. ' +
+        "Size limits: 10 MB per attachment and 15 MB total by default; executable filename " +
+        "extensions are rejected.",
     },
   },
   required: ["to", "subject"],

--- a/src/tools/sandbox/sendSandboxEmail.ts
+++ b/src/tools/sandbox/sendSandboxEmail.ts
@@ -6,6 +6,7 @@ import {
   normalizeAddressList,
   parseSandboxTo,
 } from "../../utils/mailtrapAddresses";
+import { validateAndAdaptAttachments } from "../../utils/attachments";
 
 async function sendSandboxEmail({
   test_inbox_id,
@@ -17,6 +18,7 @@ async function sendSandboxEmail({
   bcc,
   category,
   html,
+  attachments,
 }: SendSandboxEmailRequest): Promise<{ content: any[]; isError?: boolean }> {
   try {
     const inboxIdRaw = test_inbox_id ?? process.env.MAILTRAP_TEST_INBOX_ID;
@@ -63,6 +65,11 @@ async function sendSandboxEmail({
       if (bccAddresses.length > 0) {
         emailData.bcc = bccAddresses;
       }
+    }
+
+    const adaptedAttachments = validateAndAdaptAttachments(attachments);
+    if (adaptedAttachments) {
+      emailData.attachments = adaptedAttachments;
     }
 
     const response = await sandboxClient.send(emailData);

--- a/src/tools/schemas/attachmentParam.ts
+++ b/src/tools/schemas/attachmentParam.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared JSON Schema fragment for a single attachment in send-email and
+ * send-sandbox-email. Mirrors Mailtrap's public REST API field names so the
+ * shape matches the docs at https://api-docs.mailtrap.io/.
+ */
+const attachmentParamSchema = {
+  type: "object",
+  properties: {
+    content: {
+      type: "string",
+      minLength: 1,
+      description:
+        "Base64-encoded file content (no whitespace, standard padding). " +
+        "Files are never read from disk by this tool — encode the bytes yourself before passing.",
+    },
+    filename: {
+      type: "string",
+      minLength: 1,
+      description: "Filename shown to the recipient (e.g. 'report.pdf').",
+    },
+    type: {
+      type: "string",
+      description:
+        "MIME type (e.g. 'image/png', 'application/pdf'). Defaults to 'application/octet-stream' if omitted.",
+    },
+    disposition: {
+      type: "string",
+      enum: ["attachment", "inline"],
+      description:
+        "'attachment' (default) shows as a downloadable file. 'inline' embeds the content " +
+        "in the HTML body via 'cid:' references — requires 'content_id'.",
+    },
+    content_id: {
+      type: "string",
+      description:
+        "Required when disposition is 'inline'. Referenced from the HTML body as " +
+        '<img src="cid:{content_id}">. Letters, digits, ".", "_", "-" only.',
+    },
+  },
+  required: ["content", "filename"],
+  additionalProperties: false,
+} as const;
+
+export default attachmentParamSchema;

--- a/src/tools/sendEmail/__tests__/sendEmail.test.ts
+++ b/src/tools/sendEmail/__tests__/sendEmail.test.ts
@@ -307,6 +307,82 @@ describe("sendEmail", () => {
     });
   });
 
+  describe("attachments", () => {
+    const TINY_B64 = "aGVsbG8gd29ybGQ=";
+
+    it("forwards a regular attachment to the SDK in Nodemailer shape", async () => {
+      await sendEmail({
+        ...mockEmailData,
+        attachments: [
+          {
+            content: TINY_B64,
+            filename: "report.pdf",
+            type: "application/pdf",
+          },
+        ],
+      });
+
+      expect(mockClient.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: [
+            {
+              content: TINY_B64,
+              filename: "report.pdf",
+              contentType: "application/pdf",
+            },
+          ],
+        })
+      );
+    });
+
+    it("forwards an inline image with cid for HTML <img src='cid:...'> embedding", async () => {
+      await sendEmail({
+        ...mockEmailData,
+        html: '<p><img src="cid:logo"></p>',
+        attachments: [
+          {
+            content: TINY_B64,
+            filename: "logo.png",
+            type: "image/png",
+            disposition: "inline",
+            content_id: "logo",
+          },
+        ],
+      });
+
+      expect(mockClient.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: [
+            {
+              content: TINY_B64,
+              filename: "logo.png",
+              contentType: "image/png",
+              contentDisposition: "inline",
+              cid: "logo",
+            },
+          ],
+        })
+      );
+    });
+
+    it("returns isError when an attachment fails validation (blocked extension)", async () => {
+      const result = await sendEmail({
+        ...mockEmailData,
+        attachments: [{ content: TINY_B64, filename: "payload.exe" }],
+      });
+
+      expect(mockClient.send).not.toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toMatch(/blocked/);
+    });
+
+    it("omits the attachments field on the SDK call when none are provided", async () => {
+      await sendEmail(mockEmailData);
+      const sent = mockClient.send.mock.calls[0][0];
+      expect(sent.attachments).toBeUndefined();
+    });
+  });
+
   describe("errors handling", () => {
     it("should throw error when neither HTML nor TEXT is provided", async () => {
       const result = await sendEmail({

--- a/src/tools/sendEmail/schema.ts
+++ b/src/tools/sendEmail/schema.ts
@@ -1,4 +1,5 @@
 import mailtrapAddressParamSchema from "../schemas/mailtrapAddressParam";
+import attachmentParamSchema from "../schemas/attachmentParam";
 
 const sendEmailSchema = {
   type: "object",
@@ -45,6 +46,17 @@ const sendEmailSchema = {
     html: {
       type: "string",
       description: "Optional HTML version of the email body",
+    },
+    attachments: {
+      type: "array",
+      minItems: 1,
+      items: attachmentParamSchema,
+      description:
+        "Optional attachments. Each entry must include base64 `content` and `filename`. " +
+        "Set `disposition: 'inline'` plus `content_id` to embed images referenced from HTML " +
+        'as `<img src="cid:{content_id}">`; otherwise the file is delivered as a download. ' +
+        "Size limits: 10 MB per attachment and 15 MB total by default; executable filename " +
+        "extensions are rejected.",
     },
   },
   required: ["to", "subject", "category"],

--- a/src/tools/sendEmail/sendEmail.ts
+++ b/src/tools/sendEmail/sendEmail.ts
@@ -5,6 +5,7 @@ import {
   normalizeAddressList,
   normalizeToRecipients,
 } from "../../utils/mailtrapAddresses";
+import { validateAndAdaptAttachments } from "../../utils/attachments";
 
 import { requireClient } from "../../client";
 
@@ -19,6 +20,7 @@ async function sendEmail({
   bcc,
   category,
   html,
+  attachments,
 }: SendMailToolRequest): Promise<{ content: any[]; isError?: boolean }> {
   try {
     const mailtrap = requireClient("sending email", {
@@ -59,6 +61,11 @@ async function sendEmail({
       if (bccAddresses.length > 0) {
         emailData.bcc = bccAddresses;
       }
+    }
+
+    const adaptedAttachments = validateAndAdaptAttachments(attachments);
+    if (adaptedAttachments) {
+      emailData.attachments = adaptedAttachments;
     }
 
     const response = await mailtrap.send(emailData);

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -3,6 +3,24 @@
  */
 export type MailtrapAddressParam = string | { email: string; name?: string };
 
+/**
+ * One attachment in the MCP wire format. Field names match the Mailtrap REST
+ * API at https://api-docs.mailtrap.io/. Use `disposition: "inline"` together
+ * with `content_id` to embed an image referenced from HTML as
+ * `<img src="cid:{content_id}">`; otherwise the file shows as a download.
+ */
+export interface AttachmentParam {
+  /** Base64-encoded content. The tool never reads files from disk. */
+  content: string;
+  filename: string;
+  /** MIME type. Defaults to `application/octet-stream` when omitted. */
+  type?: string;
+  /** Defaults to `attachment` when omitted. */
+  disposition?: "attachment" | "inline";
+  /** Required when `disposition === "inline"`. */
+  content_id?: string;
+}
+
 export interface SendMailToolRequest {
   from?: MailtrapAddressParam;
   to: MailtrapAddressParam | MailtrapAddressParam[];
@@ -12,6 +30,7 @@ export interface SendMailToolRequest {
   cc?: MailtrapAddressParam[];
   bcc?: MailtrapAddressParam[];
   category: string;
+  attachments?: AttachmentParam[];
 }
 
 export interface CreateTemplateRequest {
@@ -60,6 +79,7 @@ export interface SendSandboxEmailRequest {
   cc?: MailtrapAddressParam[];
   bcc?: MailtrapAddressParam[];
   category?: string;
+  attachments?: AttachmentParam[];
 }
 
 export interface GetMessagesRequest {

--- a/src/utils/__tests__/attachments.test.ts
+++ b/src/utils/__tests__/attachments.test.ts
@@ -1,0 +1,184 @@
+import { validateAndAdaptAttachments } from "../attachments";
+
+/** "hello world" — well-formed base64. */
+const TINY_B64 = "aGVsbG8gd29ybGQ=";
+
+describe("validateAndAdaptAttachments", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    Object.keys(process.env).forEach((k) => {
+      if (!(k in originalEnv)) delete process.env[k];
+    });
+    Object.assign(process.env, originalEnv);
+  });
+
+  it("returns undefined for empty / missing input", () => {
+    expect(validateAndAdaptAttachments(undefined)).toBeUndefined();
+    expect(validateAndAdaptAttachments(null as any)).toBeUndefined();
+    expect(validateAndAdaptAttachments([])).toBeUndefined();
+  });
+
+  it("adapts a regular attachment to the Nodemailer shape", () => {
+    const result = validateAndAdaptAttachments([
+      {
+        content: TINY_B64,
+        filename: "report.pdf",
+        type: "application/pdf",
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        content: TINY_B64,
+        filename: "report.pdf",
+        contentType: "application/pdf",
+      },
+    ]);
+  });
+
+  it("adapts an inline image with content_id", () => {
+    const result = validateAndAdaptAttachments([
+      {
+        content: TINY_B64,
+        filename: "logo.png",
+        type: "image/png",
+        disposition: "inline",
+        content_id: "logo_image",
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        content: TINY_B64,
+        filename: "logo.png",
+        contentType: "image/png",
+        contentDisposition: "inline",
+        cid: "logo_image",
+      },
+    ]);
+  });
+
+  it("rejects inline disposition without content_id", () => {
+    expect(() =>
+      validateAndAdaptAttachments([
+        {
+          content: TINY_B64,
+          filename: "logo.png",
+          disposition: "inline",
+        },
+      ])
+    ).toThrow(/content_id/);
+  });
+
+  it("rejects unknown disposition value", () => {
+    expect(() =>
+      validateAndAdaptAttachments([
+        {
+          content: TINY_B64,
+          filename: "logo.png",
+          disposition: "embedded" as any,
+        },
+      ])
+    ).toThrow(/disposition/);
+  });
+
+  it("rejects content_id with invalid characters", () => {
+    expect(() =>
+      validateAndAdaptAttachments([
+        {
+          content: TINY_B64,
+          filename: "logo.png",
+          disposition: "inline",
+          content_id: "bad cid",
+        },
+      ])
+    ).toThrow(/content_id/);
+  });
+
+  it("rejects missing filename", () => {
+    expect(() =>
+      validateAndAdaptAttachments([{ content: TINY_B64 } as any])
+    ).toThrow(/filename/);
+  });
+
+  it("rejects missing content", () => {
+    expect(() =>
+      validateAndAdaptAttachments([{ filename: "x.txt" } as any])
+    ).toThrow(/content/);
+  });
+
+  it("rejects content that isn't valid base64", () => {
+    expect(() =>
+      validateAndAdaptAttachments([
+        { content: "not!base64!", filename: "x.txt" },
+      ])
+    ).toThrow(/base64/);
+  });
+
+  it("rejects executable extensions by default", () => {
+    expect(() =>
+      validateAndAdaptAttachments([
+        { content: TINY_B64, filename: "payload.exe" },
+      ])
+    ).toThrow(/blocked/);
+  });
+
+  it("rejects shell-script extensions and is case-insensitive", () => {
+    expect(() =>
+      validateAndAdaptAttachments([
+        { content: TINY_B64, filename: "deploy.SH" },
+      ])
+    ).toThrow(/blocked/);
+  });
+
+  it("rejects blocked MIME types even if extension is benign", () => {
+    expect(() =>
+      validateAndAdaptAttachments([
+        {
+          content: TINY_B64,
+          filename: "harmless.txt",
+          type: "application/x-msdownload",
+        },
+      ])
+    ).toThrow(/MIME/);
+  });
+
+  it("rejects an oversized single attachment using the env override", () => {
+    // 1 KB cap, but content decodes to ~12 bytes — push it past with a long
+    // base64 string that decodes to ~1.5 KB.
+    process.env.MAILTRAP_MAX_ATTACHMENT_SIZE_BYTES = "1024";
+    const oversized = "A".repeat(2400); // decodes to ~1800 bytes
+    expect(() =>
+      validateAndAdaptAttachments([
+        { content: oversized, filename: "big.pdf" },
+      ])
+    ).toThrow(/per-attachment cap/);
+  });
+
+  it("rejects when the sum of attachments exceeds the total cap", () => {
+    process.env.MAILTRAP_MAX_ATTACHMENT_SIZE_BYTES = "1000000";
+    process.env.MAILTRAP_MAX_ATTACHMENTS_TOTAL_BYTES = "2000";
+    const oneKb = "A".repeat(1400); // decodes to ~1050 bytes
+    expect(() =>
+      validateAndAdaptAttachments([
+        { content: oneKb, filename: "a.pdf" },
+        { content: oneKb, filename: "b.pdf" },
+        { content: oneKb, filename: "c.pdf" },
+      ])
+    ).toThrow(/total cap/);
+  });
+
+  it("honours custom blocked-extensions list from env", () => {
+    process.env.MAILTRAP_ATTACHMENT_BLOCKED_EXTENSIONS = ".secret";
+    // .exe is no longer blocked when the env list is overridden
+    expect(() =>
+      validateAndAdaptAttachments([
+        { content: TINY_B64, filename: "ok.exe" },
+      ])
+    ).not.toThrow();
+    expect(() =>
+      validateAndAdaptAttachments([
+        { content: TINY_B64, filename: "leak.secret" },
+      ])
+    ).toThrow(/blocked/);
+  });
+});

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -1,0 +1,258 @@
+/**
+ * Attachment validation and adaptation for Mailtrap send-email tools.
+ *
+ * The MCP exposes Mailtrap's wire-format field names (`content`, `filename`,
+ * `type`, `disposition`, `content_id`) at the tool boundary because those
+ * match the public Mailtrap API docs the LLM will reference. This module:
+ *
+ *   1. Validates each attachment (size, MIME / extension denylist, inline
+ *      disposition shape, base64 well-formedness).
+ *   2. Enforces a per-attachment cap and a sum cap across all attachments,
+ *      both overridable via env vars.
+ *   3. Adapts the validated attachments to the Nodemailer-shaped objects the
+ *      `mailtrap` SDK's `Mail.attachments` field expects.
+ *
+ * Files are never read from disk here — callers must supply already-encoded
+ * base64 content. This keeps the MCP a passive transport and forces any
+ * filesystem read to flow through a separate MCP whose permissions the user
+ * can audit independently.
+ */
+import { AttachmentParam } from "../types/mailtrap";
+
+/** Default per-attachment size cap (10 MB raw / decoded). */
+const DEFAULT_MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+/** Default sum-of-all-attachments cap (15 MB raw). Mailtrap's hard ceiling is
+ *  ~20 MB per message after base64; this leaves room for body and headers. */
+const DEFAULT_MAX_ATTACHMENTS_TOTAL_BYTES = 15 * 1024 * 1024;
+
+/**
+ * Filename extensions blocked by default. MIME types can be spoofed, so we
+ * also reject by extension. Override (for testing) via
+ * `MAILTRAP_ATTACHMENT_BLOCKED_EXTENSIONS` as a comma-separated list (lowercase,
+ * leading dot or not).
+ */
+const DEFAULT_BLOCKED_EXTENSIONS = [
+  ".exe",
+  ".bat",
+  ".cmd",
+  ".com",
+  ".scr",
+  ".pif",
+  ".lnk",
+  ".vbs",
+  ".vbe",
+  ".js",
+  ".jse",
+  ".wsf",
+  ".wsh",
+  ".ps1",
+  ".msi",
+  ".reg",
+  ".hta",
+  ".scf",
+  ".jar",
+  ".dll",
+  ".sh",
+];
+
+/** MIME types blocked by default. */
+const DEFAULT_BLOCKED_MIME_TYPES = [
+  "application/x-msdownload",
+  "application/x-msdos-program",
+  "application/x-exe",
+  "application/x-executable",
+  "application/x-shellscript",
+  "application/x-sh",
+  "text/x-shellscript",
+];
+
+/** Adapted attachment in the shape the `mailtrap` SDK expects (Nodemailer-style). */
+export interface AdaptedAttachment {
+  filename: string;
+  content: string;
+  contentType?: string;
+  contentDisposition?: "attachment" | "inline";
+  cid?: string;
+}
+
+function parsePositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+function parseListEnv(name: string, fallback: string[]): string[] {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  return raw
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => s.length > 0);
+}
+
+/** Approximate decoded byte length of a base64 string without actually decoding. */
+function approxDecodedSize(b64: string): number {
+  const padding = (b64.endsWith("==") ? 2 : b64.endsWith("=") ? 1 : 0);
+  return Math.floor((b64.length * 3) / 4) - padding;
+}
+
+/** True if `s` looks like a well-formed standard base64 string. */
+function isBase64(s: string): boolean {
+  if (s.length === 0) return false;
+  // Allow padding only at the end. No whitespace tolerated — callers should
+  // strip any line-wrapping before sending.
+  return /^[A-Za-z0-9+/]+={0,2}$/.test(s);
+}
+
+/** True if the filename ends in any of the blocked extensions (case-insensitive). */
+function hasBlockedExtension(filename: string, blocked: string[]): boolean {
+  const lower = filename.toLowerCase();
+  return blocked.some((ext) => {
+    const dotted = ext.startsWith(".") ? ext : `.${ext}`;
+    return lower.endsWith(dotted);
+  });
+}
+
+/**
+ * Validate one attachment and convert to the Nodemailer-style shape the
+ * Mailtrap SDK expects. Throws with a clear error message on any failure.
+ */
+function validateAndAdaptOne(
+  att: AttachmentParam,
+  index: number,
+  perAttachmentMax: number,
+  blockedExtensions: string[],
+  blockedMimeTypes: string[]
+): { adapted: AdaptedAttachment; decodedSize: number } {
+  const label = `attachments[${index}]`;
+
+  if (!att || typeof att !== "object") {
+    throw new Error(`${label}: must be an object`);
+  }
+  if (!att.filename || typeof att.filename !== "string") {
+    throw new Error(`${label}: 'filename' is required and must be a string`);
+  }
+  if (!att.content || typeof att.content !== "string") {
+    throw new Error(
+      `${label}: 'content' is required and must be a base64-encoded string`
+    );
+  }
+  if (!isBase64(att.content)) {
+    throw new Error(
+      `${label}: 'content' must be a base64-encoded string (no whitespace, padded with '=')`
+    );
+  }
+
+  const decodedSize = approxDecodedSize(att.content);
+  if (decodedSize > perAttachmentMax) {
+    throw new Error(
+      `${label}: decoded size ${decodedSize} bytes exceeds per-attachment cap ${perAttachmentMax} bytes ` +
+        `(override with MAILTRAP_MAX_ATTACHMENT_SIZE_BYTES)`
+    );
+  }
+
+  if (hasBlockedExtension(att.filename, blockedExtensions)) {
+    throw new Error(
+      `${label}: filename extension is blocked for safety. ` +
+        `Filename: ${att.filename}. To override, set MAILTRAP_ATTACHMENT_BLOCKED_EXTENSIONS.`
+    );
+  }
+
+  if (
+    att.type &&
+    blockedMimeTypes.includes(att.type.toLowerCase().trim())
+  ) {
+    throw new Error(
+      `${label}: MIME type '${att.type}' is blocked for safety. ` +
+        `To override, set MAILTRAP_ATTACHMENT_BLOCKED_MIME_TYPES.`
+    );
+  }
+
+  const disposition = att.disposition;
+  if (
+    disposition !== undefined &&
+    disposition !== "attachment" &&
+    disposition !== "inline"
+  ) {
+    throw new Error(
+      `${label}: 'disposition' must be 'attachment' or 'inline' if provided`
+    );
+  }
+  if (disposition === "inline") {
+    if (!att.content_id || typeof att.content_id !== "string") {
+      throw new Error(
+        `${label}: inline attachments require 'content_id' (referenced as <img src="cid:...">)`
+      );
+    }
+    if (!/^[A-Za-z0-9._-]+$/.test(att.content_id)) {
+      throw new Error(
+        `${label}: 'content_id' must contain only letters, digits, '.', '_' or '-'`
+      );
+    }
+  }
+
+  const adapted: AdaptedAttachment = {
+    filename: att.filename,
+    content: att.content,
+  };
+  if (att.type) adapted.contentType = att.type;
+  if (disposition) adapted.contentDisposition = disposition;
+  if (att.content_id) adapted.cid = att.content_id;
+
+  return { adapted, decodedSize };
+}
+
+/**
+ * Validate the full attachments array (if present) and return the
+ * Nodemailer-shaped list ready to assign to `Mail.attachments`. Returns
+ * `undefined` when the input is null/undefined/empty so callers can simply
+ * spread the result into the SDK payload.
+ */
+export function validateAndAdaptAttachments(
+  attachments: AttachmentParam[] | undefined | null
+): AdaptedAttachment[] | undefined {
+  if (!attachments || attachments.length === 0) return undefined;
+  if (!Array.isArray(attachments)) {
+    throw new Error("attachments: must be an array");
+  }
+
+  const perAttachmentMax = parsePositiveIntEnv(
+    "MAILTRAP_MAX_ATTACHMENT_SIZE_BYTES",
+    DEFAULT_MAX_ATTACHMENT_BYTES
+  );
+  const totalMax = parsePositiveIntEnv(
+    "MAILTRAP_MAX_ATTACHMENTS_TOTAL_BYTES",
+    DEFAULT_MAX_ATTACHMENTS_TOTAL_BYTES
+  );
+  const blockedExtensions = parseListEnv(
+    "MAILTRAP_ATTACHMENT_BLOCKED_EXTENSIONS",
+    DEFAULT_BLOCKED_EXTENSIONS
+  );
+  const blockedMimeTypes = parseListEnv(
+    "MAILTRAP_ATTACHMENT_BLOCKED_MIME_TYPES",
+    DEFAULT_BLOCKED_MIME_TYPES
+  );
+
+  const adapted: AdaptedAttachment[] = [];
+  let totalBytes = 0;
+  for (let i = 0; i < attachments.length; i += 1) {
+    const { adapted: one, decodedSize } = validateAndAdaptOne(
+      attachments[i],
+      i,
+      perAttachmentMax,
+      blockedExtensions,
+      blockedMimeTypes
+    );
+    totalBytes += decodedSize;
+    if (totalBytes > totalMax) {
+      throw new Error(
+        `attachments: combined decoded size exceeds total cap ${totalMax} bytes ` +
+          `(override with MAILTRAP_MAX_ATTACHMENTS_TOTAL_BYTES)`
+      );
+    }
+    adapted.push(one);
+  }
+  return adapted;
+}


### PR DESCRIPTION
## Summary

Adds optional `attachments` array to both `send-email` and `send-sandbox-email` MCP tools. Each entry uses Mailtrap's wire-format field names (`content`, `filename`, `type`, `disposition`, `content_id`) so the schema matches the public REST API docs that the LLM and developers reference. Internally the handler adapts to the Nodemailer-shape the `mailtrap` SDK's `Mail.attachments` field already accepts — no SDK changes required.

This was the highest-impact gap I hit using the MCP in production: the deployed Mailtrap extension exposes essentially every transactional surface (templates, logs, stats, sandbox, sending domains) but cannot attach anything, even though the underlying SDK and REST API support both inline images and downloadable files.

Bumps the package, manifest, and `MCP_SERVER_VERSION` from 0.3.0 to 0.3.1.

## Behaviour

**Two dispositions, one schema:**
- `disposition: "attachment"` (default) — file shows up as a download.
- `disposition: "inline"` + `content_id` — embedded in HTML via `<img src=\"cid:{content_id}\">`. The handler enforces `content_id` is present and well-formed when disposition is inline.

**No filesystem access.** The MCP only accepts already-base64-encoded `content` strings. It never reads files from disk. Reading a file to attach requires going through a separate filesystem MCP whose permissions the user can audit independently — keeping this tool a passive transport.

## Safety gates

All gates are overridable via env vars for power users, but ship with sensible defaults:

- **Per-attachment size cap:** 10 MB decoded. `MAILTRAP_MAX_ATTACHMENT_SIZE_BYTES`.
- **Total size cap:** 15 MB decoded across all attachments. `MAILTRAP_MAX_ATTACHMENTS_TOTAL_BYTES`. Mailtrap's hard API ceiling is ~20 MB per message after base64; this leaves headroom for body and headers.
- **Executable filename denylist:** `.exe`, `.bat`, `.cmd`, `.com`, `.scr`, `.pif`, `.lnk`, `.vbs`, `.vbe`, `.js`, `.jse`, `.wsf`, `.wsh`, `.ps1`, `.msi`, `.reg`, `.hta`, `.scf`, `.jar`, `.dll`, `.sh`. Case-insensitive. `MAILTRAP_ATTACHMENT_BLOCKED_EXTENSIONS`.
- **MIME denylist:** `application/x-msdownload`, `application/x-msdos-program`, `application/x-exe`, `application/x-executable`, `application/x-shellscript`, `application/x-sh`, `text/x-shellscript`. `MAILTRAP_ATTACHMENT_BLOCKED_MIME_TYPES`.
- **Base64 well-formedness:** content must match `^[A-Za-z0-9+/]+={0,2}$` (no whitespace).

Size is checked without decoding by computing the expected decoded length from the base64 string length and padding — avoids materialising large buffers just to measure them.

## Files touched

```
src/types/mailtrap.ts                          +20  (AttachmentParam + field on both request types)
src/tools/schemas/attachmentParam.ts           NEW  (shared JSON Schema fragment)
src/utils/attachments.ts                       NEW  (validator + Nodemailer adapter)
src/utils/__tests__/attachments.test.ts        NEW  (14 validator tests)
src/tools/sendEmail/schema.ts                  +12
src/tools/sendEmail/sendEmail.ts               +7   (call validator, pass to SDK)
src/tools/sandbox/schemas/sendSandboxEmail.ts  +12
src/tools/sandbox/sendSandboxEmail.ts          +7
src/tools/sendEmail/__tests__/sendEmail.test.ts        +76  (4 integration tests)
src/tools/sandbox/__tests__/sendSandboxEmail.test.ts   +70  (4 integration tests)
README.md                                      +60  (Attachments section)
manifest.json, package.json, src/config/index.ts       version bump
```

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 193 tests pass (171 existing + 22 new)
- [x] `npm run build` clean
- [x] Manually started the built server, sent an `initialize` + `tools/list` over stdio, confirmed `send-email` and `send-sandbox-email` both expose an `attachments` property in their `inputSchema`
- [x] Loaded the patched build as the live Mailtrap extension in Claude Desktop on two Macs (Apple Silicon, Node 26) — the new schema appears in the tool list, existing calls without `attachments` are unchanged
- [ ] Live end-to-end send with inline image — verified locally outside this branch via the same handler path; happy to do a recorded round-trip if you want it before merging

## Notes for review

- Wire-format field names at the MCP boundary were a deliberate choice (`content_id` vs Nodemailer's `cid`, `disposition` vs `contentDisposition`). This matches `api-docs.mailtrap.io` so LLMs and developers reading either set of docs use the same vocabulary. The handler converts to the Nodemailer shape the SDK expects.
- The validator is in `src/utils/` (not under `tools/sendEmail/`) because both send-email and send-sandbox-email need it. Same approach as the existing `mailtrapAddresses.ts`.
- Filename extension denylist is intentionally a denylist rather than allowlist — an allowlist would be too restrictive for transactional use (legitimate exports to .csv, .ics, .vcf, .zip, .docx, etc. would all need explicit entries).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email attachment support with inline or downloadable options for both standard and sandbox sending modes

* **Documentation**
  * Updated with attachment parameter documentation including required fields (content, filename), optional fields (type, disposition, content_id), usage examples for inline images and downloadable PDFs, and safety limits covering attachment size caps and blocked executable extensions/MIME types

* **Chores**
  * Version bumped to 0.3.1

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailtrap/mailtrap-mcp/pull/85)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->