### PR TITLE
Add sandbox tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,12 @@ Schema files define a JSON Schema–shaped object for MCP; optional Zod schemas 
 - **get-sandbox-messages**: Get list of messages from the sandbox test inbox.
 - **show-sandbox-email-message**: Show sandbox email message details and content from the sandbox test inbox.
 - **list-sandbox-projects** / **create-sandbox-project** / **get-sandbox-project** / **update-sandbox-project** / **delete-sandbox-project**: Manage sandbox projects (group of inboxes).
+- **list-sandboxes**: List all sandboxes accessible to the API token across projects.
+- **mark-sandbox-as-read** / **reset-sandbox-credentials** / **enable-sandbox-email-address** / **reset-sandbox-email-address**: Single-action sandbox operations.
+- **forward-sandbox-message** / **update-sandbox-message** / **delete-sandbox-message**: Mutate a single sandbox message.
+- **get-sandbox-message-spam-score** / **get-sandbox-message-html-analysis** / **get-sandbox-message-headers**: Inspect a sandbox message's spam report, HTML compatibility, or headers (standalone alternatives to the `include_*` flags on `show-sandbox-email-message`).
+- **get-sandbox-message-html** / **get-sandbox-message-text** / **get-sandbox-message-raw** / **get-sandbox-message-eml** / **get-sandbox-message-html-source**: Fetch a single message body in one of five formats.
+- **list-sandbox-attachments** / **get-sandbox-attachment**: List and inspect attachments on a sandbox message.
 
 
 #### Sending Domains

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Before using this MCP server, you need to:
 
 - `DEFAULT_FROM_EMAIL` - Default sender email when `from` is not provided to send-email or send-sandbox-email. Enables switching sender per call via the `from` parameter.
 - `MAILTRAP_TEST_INBOX_ID` - Default test inbox ID for sandbox tools when `test_inbox_id` is not provided. Enables switching between inboxes per call via the `test_inbox_id` parameter.
+- `MAILTRAP_SANDBOX_ID` - Default sandbox ID for sandbox tools when `sandbox_id` is not provided. Enables switching between sandboxes per call via the `sandbox_id` parameter.
 
 ## Quick Install
 
@@ -381,6 +382,166 @@ Rename an existing sandbox project.
 
 - `project_id` (required): ID of the project to update
 - `name` (required): New name for the project (2–100 characters)
+
+### list-sandboxes
+
+List every sandbox accessible to the API token across all projects.
+
+**Parameters:**
+
+- No parameters required
+
+### mark-sandbox-as-read
+
+Mark all messages in a sandbox as read.
+
+**Parameters:**
+
+- `sandbox_id` (required): ID of the sandbox to act on
+
+### reset-sandbox-credentials
+
+Reset the SMTP credentials for a sandbox. Returns the new username/password.
+
+**Parameters:**
+
+- `sandbox_id` (required): ID of the sandbox to act on
+
+### enable-sandbox-email-address
+
+Enable the receive-by-email address for a sandbox (turns on the Mailtrap address that delivers messages to the sandbox via SMTP).
+
+**Parameters:**
+
+- `sandbox_id` (required): ID of the sandbox to act on
+
+### reset-sandbox-email-address
+
+Generate a new receive-by-email address for a sandbox.
+
+**Parameters:**
+
+- `sandbox_id` (required): ID of the sandbox to act on
+
+### forward-sandbox-message
+
+Forward a sandbox message to an external email address. Counts against your monthly forwarding quota.
+
+**Parameters:**
+
+- `sandbox_id` (optional): Sandbox ID. Falls back to `MAILTRAP_SANDBOX_ID`.
+- `message_id` (required): ID of the sandbox message to forward
+- `email` (required): Email address to forward the message to
+
+### update-sandbox-message
+
+Mark a sandbox message as read or unread.
+
+**Parameters:**
+
+- `sandbox_id` (optional): Sandbox ID. Falls back to `MAILTRAP_SANDBOX_ID`.
+- `message_id` (required): ID of the sandbox message to update
+- `is_read` (required): `true` marks as read, `false` marks as unread
+
+### delete-sandbox-message
+
+Delete a single sandbox message.
+
+**Parameters:**
+
+- `sandbox_id` (optional): Sandbox ID. Falls back to `MAILTRAP_SANDBOX_ID`.
+- `message_id` (required): ID of the sandbox message to delete
+
+### get-sandbox-message-spam-score
+
+Get the SpamAssassin spam report for a sandbox message (score, rules, full report). Standalone alternative to `include_spam_report: true` on `show-sandbox-email-message`.
+
+**Parameters:**
+
+- `sandbox_id` (optional): Sandbox ID. Falls back to `MAILTRAP_SANDBOX_ID`.
+- `message_id` (required): ID of the sandbox message
+
+### get-sandbox-message-html-analysis
+
+Get the HTML analysis report for a sandbox message (client compatibility scores, problematic elements). Standalone alternative to `include_html_analysis: true` on `show-sandbox-email-message`.
+
+**Parameters:**
+
+- `sandbox_id` (optional): Sandbox ID. Falls back to `MAILTRAP_SANDBOX_ID`.
+- `message_id` (required): ID of the sandbox message
+
+### get-sandbox-message-headers
+
+Get the parsed mail headers for a sandbox message.
+
+**Parameters:**
+
+- `sandbox_id` (optional): Sandbox ID. Falls back to `MAILTRAP_SANDBOX_ID`.
+- `message_id` (required): ID of the sandbox message
+
+### get-sandbox-message-html
+
+Get the rendered HTML body of a sandbox message.
+
+**Parameters:**
+
+- `sandbox_id` (optional): Sandbox ID. Falls back to `MAILTRAP_SANDBOX_ID`.
+- `message_id` (required): ID of the sandbox message
+
+### get-sandbox-message-text
+
+Get the plain-text body of a sandbox message.
+
+**Parameters:**
+
+- `sandbox_id` (optional): Sandbox ID. Falls back to `MAILTRAP_SANDBOX_ID`.
+- `message_id` (required): ID of the sandbox message
+
+### get-sandbox-message-raw
+
+Get the raw, MIME-formatted message (headers + body) for a sandbox message.
+
+**Parameters:**
+
+- `sandbox_id` (optional): Sandbox ID. Falls back to `MAILTRAP_SANDBOX_ID`.
+- `message_id` (required): ID of the sandbox message
+
+### get-sandbox-message-eml
+
+Get the message rendered as an EML file payload (suitable for attaching to a ticket or importing into another mail client).
+
+**Parameters:**
+
+- `sandbox_id` (optional): Sandbox ID. Falls back to `MAILTRAP_SANDBOX_ID`.
+- `message_id` (required): ID of the sandbox message
+
+### get-sandbox-message-html-source
+
+Get the unrendered HTML source of a sandbox message (HTML before any Mailtrap-side transformations like CID-link rewrites).
+
+**Parameters:**
+
+- `sandbox_id` (optional): Sandbox ID. Falls back to `MAILTRAP_SANDBOX_ID`.
+- `message_id` (required): ID of the sandbox message
+
+### list-sandbox-attachments
+
+List all attachments on a sandbox message (filename, content type, size, download path).
+
+**Parameters:**
+
+- `sandbox_id` (optional): Sandbox ID. Falls back to `MAILTRAP_SANDBOX_ID`.
+- `message_id` (required): ID of the sandbox message
+
+### get-sandbox-attachment
+
+Get metadata and download URL for a single attachment.
+
+**Parameters:**
+
+- `sandbox_id` (optional): Sandbox ID. Falls back to `MAILTRAP_SANDBOX_ID`.
+- `message_id` (required): ID of the sandbox message that contains the attachment
+- `attachment_id` (required): ID of the attachment to fetch
 
 ### list-sending-domains
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,6 +51,33 @@ import {
   deleteSandboxInboxSchema,
   cleanSandboxInbox,
   cleanSandboxInboxSchema,
+  // Sandbox management additions
+  listSandboxes,
+  listSandboxesSchema,
+  sandboxActionSchema,
+  markSandboxAsRead,
+  resetSandboxCredentials,
+  enableSandboxEmailAddress,
+  resetSandboxEmailAddress,
+  // Message management additions
+  sandboxMessageSchema,
+  forwardSandboxMessageSchema,
+  updateSandboxMessageSchema,
+  forwardSandboxMessage,
+  updateSandboxMessage,
+  deleteSandboxMessage,
+  getSandboxMessageSpamScore,
+  getSandboxMessageHtmlAnalysis,
+  getSandboxMessageHeaders,
+  getSandboxMessageHtml,
+  getSandboxMessageText,
+  getSandboxMessageRaw,
+  getSandboxMessageEml,
+  getSandboxMessageHtmlSource,
+  // Attachment additions
+  getSandboxAttachmentSchema,
+  listSandboxAttachments,
+  getSandboxAttachment,
 } from "./tools/sandbox";
 import { getSendingStats, getSendingStatsSchema } from "./tools/stats";
 import {
@@ -252,6 +279,173 @@ const tools = [
     handler: cleanSandboxInbox,
     annotations: {
       destructiveHint: true,
+    },
+  },
+  {
+    name: "list-sandboxes",
+    description:
+      "List all sandboxes accessible to the API token across projects",
+    inputSchema: listSandboxesSchema,
+    handler: listSandboxes,
+    annotations: {
+      readOnlyHint: true,
+    },
+  },
+  {
+    name: "mark-sandbox-as-read",
+    description: "Mark all messages in a sandbox as read",
+    inputSchema: sandboxActionSchema,
+    handler: markSandboxAsRead,
+    annotations: {
+      destructiveHint: true,
+    },
+  },
+  {
+    name: "reset-sandbox-credentials",
+    description: "Reset the SMTP credentials for a sandbox",
+    inputSchema: sandboxActionSchema,
+    handler: resetSandboxCredentials,
+    annotations: {
+      destructiveHint: true,
+    },
+  },
+  {
+    name: "enable-sandbox-email-address",
+    description: "Enable the receive-by-email address for a sandbox",
+    inputSchema: sandboxActionSchema,
+    handler: enableSandboxEmailAddress,
+    annotations: {
+      destructiveHint: true,
+    },
+  },
+  {
+    name: "reset-sandbox-email-address",
+    description: "Generate a new receive-by-email address for a sandbox",
+    inputSchema: sandboxActionSchema,
+    handler: resetSandboxEmailAddress,
+    annotations: {
+      destructiveHint: true,
+    },
+  },
+  {
+    name: "forward-sandbox-message",
+    description:
+      "Forward a sandbox message to an email address (counts against your monthly forwarding quota)",
+    inputSchema: forwardSandboxMessageSchema,
+    handler: forwardSandboxMessage,
+    annotations: {
+      destructiveHint: false,
+    },
+  },
+  {
+    name: "update-sandbox-message",
+    description: "Mark a sandbox message as read or unread",
+    inputSchema: updateSandboxMessageSchema,
+    handler: updateSandboxMessage,
+    annotations: {
+      destructiveHint: true,
+    },
+  },
+  {
+    name: "delete-sandbox-message",
+    description: "Delete a single sandbox message",
+    inputSchema: sandboxMessageSchema,
+    handler: deleteSandboxMessage,
+    annotations: {
+      destructiveHint: true,
+    },
+  },
+  {
+    name: "get-sandbox-message-spam-score",
+    description:
+      "Get the SpamAssassin spam report for a sandbox message (score, rules, report).",
+    inputSchema: sandboxMessageSchema,
+    handler: getSandboxMessageSpamScore,
+    annotations: {
+      readOnlyHint: true,
+    },
+  },
+  {
+    name: "get-sandbox-message-html-analysis",
+    description:
+      "Get HTML analysis for a sandbox message (client compatibility, problematic elements).",
+    inputSchema: sandboxMessageSchema,
+    handler: getSandboxMessageHtmlAnalysis,
+    annotations: {
+      readOnlyHint: true,
+    },
+  },
+  {
+    name: "get-sandbox-message-headers",
+    description: "Get the parsed mail headers for a sandbox message.",
+    inputSchema: sandboxMessageSchema,
+    handler: getSandboxMessageHeaders,
+    annotations: {
+      readOnlyHint: true,
+    },
+  },
+  {
+    name: "get-sandbox-message-html",
+    description: "Get the rendered HTML body of a sandbox message.",
+    inputSchema: sandboxMessageSchema,
+    handler: getSandboxMessageHtml,
+    annotations: {
+      readOnlyHint: true,
+    },
+  },
+  {
+    name: "get-sandbox-message-text",
+    description: "Get the plain-text body of a sandbox message.",
+    inputSchema: sandboxMessageSchema,
+    handler: getSandboxMessageText,
+    annotations: {
+      readOnlyHint: true,
+    },
+  },
+  {
+    name: "get-sandbox-message-raw",
+    description: "Get the raw message (MIME-formatted) for a sandbox message.",
+    inputSchema: sandboxMessageSchema,
+    handler: getSandboxMessageRaw,
+    annotations: {
+      readOnlyHint: true,
+    },
+  },
+  {
+    name: "get-sandbox-message-eml",
+    description: "Get a sandbox message as an EML file payload.",
+    inputSchema: sandboxMessageSchema,
+    handler: getSandboxMessageEml,
+    annotations: {
+      readOnlyHint: true,
+    },
+  },
+  {
+    name: "get-sandbox-message-html-source",
+    description: "Get the unrendered HTML source of a sandbox message.",
+    inputSchema: sandboxMessageSchema,
+    handler: getSandboxMessageHtmlSource,
+    annotations: {
+      readOnlyHint: true,
+    },
+  },
+  {
+    name: "list-sandbox-attachments",
+    description: "List all attachments on a sandbox message.",
+    inputSchema: sandboxMessageSchema,
+    handler: listSandboxAttachments,
+    annotations: {
+      readOnlyHint: true,
+    },
+  },
+  {
+    name: "get-sandbox-attachment",
+    description:
+      "Get the metadata and download URL for a single sandbox attachment.",
+    inputSchema: getSandboxAttachmentSchema,
+    handler: getSandboxAttachment,
+    annotations: {
+      readOnlyHint: true,
     },
   },
   {

--- a/src/tools/sandbox/__tests__/forwardSandboxMessage.test.ts
+++ b/src/tools/sandbox/__tests__/forwardSandboxMessage.test.ts
@@ -1,0 +1,72 @@
+import forwardSandboxMessage from "../forwardSandboxMessage";
+import { getSandboxClient } from "../../../client";
+
+const mockSandboxClient = {
+  testing: {
+    messages: {
+      forward: jest.fn(),
+    },
+  },
+};
+
+jest.mock("../../../client", () => ({
+  getSandboxClient: jest.fn(() => mockSandboxClient),
+}));
+
+const originalEnv = { ...process.env };
+
+describe("forwardSandboxMessage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getSandboxClient as jest.Mock).mockReturnValue(mockSandboxClient);
+    Object.assign(process.env, { MAILTRAP_SANDBOX_ID: "1234" });
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, originalEnv);
+  });
+
+  it("forwards the message", async () => {
+    mockSandboxClient.testing.messages.forward.mockResolvedValue({});
+
+    const result = await forwardSandboxMessage({
+      message_id: 99,
+      email: "user@example.com",
+    });
+
+    expect(getSandboxClient).toHaveBeenCalledWith(1234);
+    expect(mockSandboxClient.testing.messages.forward).toHaveBeenCalledWith(
+      1234,
+      99,
+      "user@example.com"
+    );
+    expect(result.content[0].text).toContain(
+      "Sandbox message 99 forwarded to user@example.com"
+    );
+  });
+
+  it("uses explicit sandbox_id over env", async () => {
+    mockSandboxClient.testing.messages.forward.mockResolvedValue({});
+
+    await forwardSandboxMessage({
+      sandbox_id: 555,
+      message_id: 99,
+      email: "a@b.com",
+    });
+
+    expect(getSandboxClient).toHaveBeenCalledWith(555);
+  });
+
+  it("errors when no sandbox id is available", async () => {
+    delete process.env.MAILTRAP_SANDBOX_ID;
+    const result = await forwardSandboxMessage({
+      message_id: 99,
+      email: "a@b.com",
+    });
+
+    expect(result.content[0].text).toContain(
+      "Provide sandbox_id or set MAILTRAP_SANDBOX_ID"
+    );
+    expect(result.isError).toBe(true);
+  });
+});

--- a/src/tools/sandbox/__tests__/listSandboxes.test.ts
+++ b/src/tools/sandbox/__tests__/listSandboxes.test.ts
@@ -1,0 +1,57 @@
+import listSandboxes from "../listSandboxes";
+import { requireClient } from "../../../client";
+
+const mockClient = {
+  testing: {
+    inboxes: {
+      getList: jest.fn(),
+    },
+  },
+};
+
+jest.mock("../../../client", () => ({
+  requireClient: jest.fn(() => mockClient),
+}));
+
+describe("listSandboxes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  it("renders all sandboxes", async () => {
+    mockClient.testing.inboxes.getList.mockResolvedValue([
+      { id: 1, name: "A", project_id: 10, emails_count: 4 },
+      { id: 2, name: "B", project_id: 11, emails_count: 0 },
+    ]);
+
+    const result = await listSandboxes();
+
+    expect(requireClient).toHaveBeenCalledWith("sandboxes");
+    expect(result.content[0].text).toContain("Sandboxes (2):");
+    expect(result.content[0].text).toContain(
+      "A (ID: 1, project: 10, emails: 4)"
+    );
+    expect(result.content[0].text).toContain(
+      "B (ID: 2, project: 11, emails: 0)"
+    );
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("handles empty list", async () => {
+    mockClient.testing.inboxes.getList.mockResolvedValue([]);
+
+    const result = await listSandboxes();
+
+    expect(result.content[0].text).toContain("No sandboxes");
+  });
+
+  it("handles API failure", async () => {
+    mockClient.testing.inboxes.getList.mockRejectedValue(new Error("boom"));
+
+    const result = await listSandboxes();
+
+    expect(result.content[0].text).toContain("Failed to list sandboxes");
+    expect(result.isError).toBe(true);
+  });
+});

--- a/src/tools/sandbox/__tests__/sandboxActions.test.ts
+++ b/src/tools/sandbox/__tests__/sandboxActions.test.ts
@@ -1,0 +1,108 @@
+import markSandboxAsRead from "../markSandboxAsRead";
+import resetSandboxCredentials from "../resetSandboxCredentials";
+import enableSandboxEmailAddress from "../enableSandboxEmailAddress";
+import resetSandboxEmailAddress from "../resetSandboxEmailAddress";
+import { requireClient } from "../../../client";
+
+const mockClient = {
+  testing: {
+    inboxes: {
+      markAsRead: jest.fn(),
+      resetCredentials: jest.fn(),
+      enableEmailAddress: jest.fn(),
+      resetEmailAddress: jest.fn(),
+    },
+  },
+};
+
+jest.mock("../../../client", () => ({
+  requireClient: jest.fn(() => mockClient),
+}));
+
+describe("sandbox single-action tools", () => {
+  const sandboxId = 555;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  describe("markSandboxAsRead", () => {
+    it("marks sandbox as read", async () => {
+      mockClient.testing.inboxes.markAsRead.mockResolvedValue({
+        id: sandboxId,
+        name: "Test",
+      });
+
+      const result = await markSandboxAsRead({ sandbox_id: sandboxId });
+
+      expect(mockClient.testing.inboxes.markAsRead).toHaveBeenCalledWith(
+        sandboxId
+      );
+      expect(result.content[0].text).toContain(
+        `Marked all messages in sandbox "Test"`
+      );
+      expect(result.isError).toBeUndefined();
+    });
+
+    it("handles failure", async () => {
+      mockClient.testing.inboxes.markAsRead.mockRejectedValue(
+        new Error("not found")
+      );
+      const result = await markSandboxAsRead({ sandbox_id: sandboxId });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("resetSandboxCredentials", () => {
+    it("returns new credentials", async () => {
+      mockClient.testing.inboxes.resetCredentials.mockResolvedValue({
+        id: sandboxId,
+        name: "Test",
+        username: "u",
+        password: "p",
+      });
+
+      const result = await resetSandboxCredentials({ sandbox_id: sandboxId });
+
+      expect(mockClient.testing.inboxes.resetCredentials).toHaveBeenCalledWith(
+        sandboxId
+      );
+      expect(result.content[0].text).toContain("Username: u");
+      expect(result.content[0].text).toContain("Password: p");
+    });
+  });
+
+  describe("enableSandboxEmailAddress", () => {
+    it("returns the resolved address", async () => {
+      mockClient.testing.inboxes.enableEmailAddress.mockResolvedValue({
+        id: sandboxId,
+        name: "Test",
+        email_username: "u",
+        email_domain: "d.com",
+      });
+
+      const result = await enableSandboxEmailAddress({ sandbox_id: sandboxId });
+
+      expect(
+        mockClient.testing.inboxes.enableEmailAddress
+      ).toHaveBeenCalledWith(sandboxId);
+      expect(result.content[0].text).toContain("Address: u@d.com");
+    });
+  });
+
+  describe("resetSandboxEmailAddress", () => {
+    it("returns the new address", async () => {
+      mockClient.testing.inboxes.resetEmailAddress.mockResolvedValue({
+        id: sandboxId,
+        name: "Test",
+        email_username: "new",
+        email_domain: "d.com",
+      });
+
+      const result = await resetSandboxEmailAddress({ sandbox_id: sandboxId });
+
+      expect(result.content[0].text).toContain("New address: new@d.com");
+    });
+  });
+});

--- a/src/tools/sandbox/__tests__/sandboxAttachments.test.ts
+++ b/src/tools/sandbox/__tests__/sandboxAttachments.test.ts
@@ -1,0 +1,107 @@
+import listSandboxAttachments from "../listSandboxAttachments";
+import getSandboxAttachment from "../getSandboxAttachment";
+import { getSandboxClient } from "../../../client";
+
+const mockSandboxClient = {
+  testing: {
+    attachments: {
+      getList: jest.fn(),
+      get: jest.fn(),
+    },
+  },
+};
+
+jest.mock("../../../client", () => ({
+  getSandboxClient: jest.fn(() => mockSandboxClient),
+}));
+
+const originalEnv = { ...process.env };
+
+describe("sandbox attachment tools", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getSandboxClient as jest.Mock).mockReturnValue(mockSandboxClient);
+    Object.assign(process.env, { MAILTRAP_SANDBOX_ID: "1234" });
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, originalEnv);
+  });
+
+  describe("listSandboxAttachments", () => {
+    it("renders the attachment list", async () => {
+      mockSandboxClient.testing.attachments.getList.mockResolvedValue([
+        {
+          id: 1,
+          filename: "a.png",
+          content_type: "image/png",
+          attachment_size: 1024,
+        },
+        {
+          id: 2,
+          filename: "b.pdf",
+          content_type: "application/pdf",
+          attachment_size: 2048,
+        },
+      ]);
+
+      const result = await listSandboxAttachments({ message_id: 99 });
+
+      expect(
+        mockSandboxClient.testing.attachments.getList
+      ).toHaveBeenCalledWith(1234, 99);
+      expect(result.content[0].text).toContain(
+        "Attachments on sandbox message 99 (2)"
+      );
+      expect(result.content[0].text).toContain(
+        "a.png (ID: 1, type: image/png, size: 1024 bytes)"
+      );
+    });
+
+    it("handles empty list", async () => {
+      mockSandboxClient.testing.attachments.getList.mockResolvedValue([]);
+
+      const result = await listSandboxAttachments({ message_id: 99 });
+
+      expect(result.content[0].text).toContain(
+        "No attachments on sandbox message 99"
+      );
+    });
+  });
+
+  describe("getSandboxAttachment", () => {
+    it("returns attachment metadata as JSON", async () => {
+      mockSandboxClient.testing.attachments.get.mockResolvedValue({
+        id: 1,
+        filename: "a.png",
+        download_path: "/api/.../1",
+      });
+
+      const result = await getSandboxAttachment({
+        message_id: 99,
+        attachment_id: 1,
+      });
+
+      expect(mockSandboxClient.testing.attachments.get).toHaveBeenCalledWith(
+        1234,
+        99,
+        1
+      );
+      expect(result.content[0].text).toContain('"filename": "a.png"');
+      expect(result.content[0].text).toContain('"download_path"');
+    });
+
+    it("handles failure", async () => {
+      mockSandboxClient.testing.attachments.get.mockRejectedValue(
+        new Error("not found")
+      );
+
+      const result = await getSandboxAttachment({
+        message_id: 99,
+        attachment_id: 1,
+      });
+
+      expect(result.isError).toBe(true);
+    });
+  });
+});

--- a/src/tools/sandbox/__tests__/sandboxMessageGetters.test.ts
+++ b/src/tools/sandbox/__tests__/sandboxMessageGetters.test.ts
@@ -1,0 +1,145 @@
+import deleteSandboxMessage from "../deleteSandboxMessage";
+import getSandboxMessageSpamScore from "../getSandboxMessageSpamScore";
+import getSandboxMessageHtmlAnalysis from "../getSandboxMessageHtmlAnalysis";
+import getSandboxMessageHeaders from "../getSandboxMessageHeaders";
+import getSandboxMessageHtml from "../getSandboxMessageHtml";
+import getSandboxMessageText from "../getSandboxMessageText";
+import getSandboxMessageRaw from "../getSandboxMessageRaw";
+import getSandboxMessageEml from "../getSandboxMessageEml";
+import getSandboxMessageHtmlSource from "../getSandboxMessageHtmlSource";
+import { getSandboxClient } from "../../../client";
+
+const mockSandboxClient = {
+  testing: {
+    messages: {
+      deleteMessage: jest.fn(),
+      getSpamScore: jest.fn(),
+      getHtmlAnalysis: jest.fn(),
+      getMailHeaders: jest.fn(),
+      getHtmlMessage: jest.fn(),
+      getTextMessage: jest.fn(),
+      getRawMessage: jest.fn(),
+      getMessageAsEml: jest.fn(),
+      getMessageHtmlSource: jest.fn(),
+    },
+  },
+};
+
+jest.mock("../../../client", () => ({
+  getSandboxClient: jest.fn(() => mockSandboxClient),
+}));
+
+const originalEnv = { ...process.env };
+
+const cases: Array<{
+  name: string;
+  handler: any;
+  method: keyof typeof mockSandboxClient.testing.messages;
+  mockValue: unknown;
+  expectedFragment: string;
+}> = [
+  {
+    name: "deleteSandboxMessage",
+    handler: deleteSandboxMessage,
+    method: "deleteMessage",
+    mockValue: {},
+    expectedFragment: "Sandbox message 99 deleted",
+  },
+  {
+    name: "getSandboxMessageSpamScore",
+    handler: getSandboxMessageSpamScore,
+    method: "getSpamScore",
+    mockValue: { score: 2.1 },
+    expectedFragment: '"score": 2.1',
+  },
+  {
+    name: "getSandboxMessageHtmlAnalysis",
+    handler: getSandboxMessageHtmlAnalysis,
+    method: "getHtmlAnalysis",
+    mockValue: { html_compatibility_score: 90 },
+    expectedFragment: '"html_compatibility_score": 90',
+  },
+  {
+    name: "getSandboxMessageHeaders",
+    handler: getSandboxMessageHeaders,
+    method: "getMailHeaders",
+    mockValue: { headers: [{ key: "Subject", value: "Hi" }] },
+    expectedFragment: '"Subject"',
+  },
+  {
+    name: "getSandboxMessageHtml",
+    handler: getSandboxMessageHtml,
+    method: "getHtmlMessage",
+    mockValue: "<p>hi</p>",
+    expectedFragment: "<p>hi</p>",
+  },
+  {
+    name: "getSandboxMessageText",
+    handler: getSandboxMessageText,
+    method: "getTextMessage",
+    mockValue: "hello",
+    expectedFragment: "hello",
+  },
+  {
+    name: "getSandboxMessageRaw",
+    handler: getSandboxMessageRaw,
+    method: "getRawMessage",
+    mockValue: "Subject: test\r\n",
+    expectedFragment: "Subject: test",
+  },
+  {
+    name: "getSandboxMessageEml",
+    handler: getSandboxMessageEml,
+    method: "getMessageAsEml",
+    mockValue: "Content-Type: text/plain",
+    expectedFragment: "Content-Type",
+  },
+  {
+    name: "getSandboxMessageHtmlSource",
+    handler: getSandboxMessageHtmlSource,
+    method: "getMessageHtmlSource",
+    mockValue: "<html></html>",
+    expectedFragment: "<html></html>",
+  },
+];
+
+describe("sandbox message getter tools", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getSandboxClient as jest.Mock).mockReturnValue(mockSandboxClient);
+    Object.assign(process.env, { MAILTRAP_SANDBOX_ID: "1234" });
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, originalEnv);
+  });
+
+  it.each(cases)(
+    "$name calls the SDK and returns the response",
+    async ({ handler, method, mockValue, expectedFragment }) => {
+      (
+        mockSandboxClient.testing.messages[method] as jest.Mock
+      ).mockResolvedValue(mockValue);
+
+      const result = await handler({ message_id: 99 });
+
+      expect(mockSandboxClient.testing.messages[method]).toHaveBeenCalledWith(
+        1234,
+        99
+      );
+      expect(result.content[0].text).toContain(expectedFragment);
+      expect(result.isError).toBeUndefined();
+    }
+  );
+
+  it.each(cases)("$name surfaces API errors", async ({ handler, method }) => {
+    (mockSandboxClient.testing.messages[method] as jest.Mock).mockRejectedValue(
+      new Error("boom")
+    );
+
+    const result = await handler({ message_id: 99 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("boom");
+  });
+});

--- a/src/tools/sandbox/__tests__/updateSandboxMessage.test.ts
+++ b/src/tools/sandbox/__tests__/updateSandboxMessage.test.ts
@@ -1,0 +1,76 @@
+import updateSandboxMessage from "../updateSandboxMessage";
+import { getSandboxClient } from "../../../client";
+
+const mockSandboxClient = {
+  testing: {
+    messages: {
+      updateMessage: jest.fn(),
+    },
+  },
+};
+
+jest.mock("../../../client", () => ({
+  getSandboxClient: jest.fn(() => mockSandboxClient),
+}));
+
+const originalEnv = { ...process.env };
+
+describe("updateSandboxMessage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getSandboxClient as jest.Mock).mockReturnValue(mockSandboxClient);
+    Object.assign(process.env, { MAILTRAP_SANDBOX_ID: "1234" });
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, originalEnv);
+  });
+
+  it("marks the message as read", async () => {
+    mockSandboxClient.testing.messages.updateMessage.mockResolvedValue({
+      id: 99,
+      is_read: true,
+    });
+
+    const result = await updateSandboxMessage({
+      message_id: 99,
+      is_read: true,
+    });
+
+    expect(
+      mockSandboxClient.testing.messages.updateMessage
+    ).toHaveBeenCalledWith(1234, 99, { isRead: true });
+    expect(result.content[0].text).toContain(
+      "Sandbox message 99 marked as read"
+    );
+  });
+
+  it("marks the message as unread", async () => {
+    mockSandboxClient.testing.messages.updateMessage.mockResolvedValue({
+      id: 99,
+      is_read: false,
+    });
+
+    const result = await updateSandboxMessage({
+      message_id: 99,
+      is_read: false,
+    });
+
+    expect(result.content[0].text).toContain(
+      "Sandbox message 99 marked as unread"
+    );
+  });
+
+  it("handles failure", async () => {
+    mockSandboxClient.testing.messages.updateMessage.mockRejectedValue(
+      new Error("not found")
+    );
+
+    const result = await updateSandboxMessage({
+      message_id: 99,
+      is_read: true,
+    });
+
+    expect(result.isError).toBe(true);
+  });
+});

--- a/src/tools/sandbox/deleteSandboxMessage.ts
+++ b/src/tools/sandbox/deleteSandboxMessage.ts
@@ -1,39 +1,25 @@
 import { getSandboxClient } from "../../client";
 import { SandboxMessageRequest } from "../../types/mailtrap";
 import resolveSandboxId from "./utils/resolveSandboxId";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
 
 async function deleteSandboxMessage({
   sandbox_id,
   message_id,
-}: SandboxMessageRequest): Promise<{
-  content: { type: string; text: string }[];
-  isError?: boolean;
-}> {
+}: SandboxMessageRequest): Promise<ToolResponse> {
   try {
     const sandboxId = resolveSandboxId(sandbox_id);
     const sandboxClient = getSandboxClient(sandboxId);
 
     await sandboxClient.testing.messages.deleteMessage(sandboxId, message_id);
 
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Sandbox message ${message_id} deleted.`,
-        },
-      ],
-    };
+    return buildSuccessResponse(`Sandbox message ${message_id} deleted.`);
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Failed to delete sandbox message: ${errorMessage}`,
-        },
-      ],
-      isError: true,
-    };
+    return buildErrorResponse("delete sandbox message", error);
   }
 }
 

--- a/src/tools/sandbox/deleteSandboxMessage.ts
+++ b/src/tools/sandbox/deleteSandboxMessage.ts
@@ -1,0 +1,40 @@
+import { getSandboxClient } from "../../client";
+import { SandboxMessageRequest } from "../../types/mailtrap";
+import resolveSandboxId from "./utils/resolveSandboxId";
+
+async function deleteSandboxMessage({
+  sandbox_id,
+  message_id,
+}: SandboxMessageRequest): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    const sandboxId = resolveSandboxId(sandbox_id);
+    const sandboxClient = getSandboxClient(sandboxId);
+
+    await sandboxClient.testing.messages.deleteMessage(sandboxId, message_id);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Sandbox message ${message_id} deleted.`,
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to delete sandbox message: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default deleteSandboxMessage;

--- a/src/tools/sandbox/enableSandboxEmailAddress.ts
+++ b/src/tools/sandbox/enableSandboxEmailAddress.ts
@@ -1,12 +1,14 @@
 import { requireClient } from "../../client";
 import { SandboxIdRequest } from "../../types/mailtrap";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
 
 async function enableSandboxEmailAddress({
   sandbox_id,
-}: SandboxIdRequest): Promise<{
-  content: { type: string; text: string }[];
-  isError?: boolean;
-}> {
+}: SandboxIdRequest): Promise<ToolResponse> {
   try {
     const mailtrap = requireClient("sandboxes");
 
@@ -14,25 +16,11 @@ async function enableSandboxEmailAddress({
       sandbox_id
     );
 
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Email address for sandbox "${sandbox.name}" (ID: ${sandbox.id}) enabled. Address: ${sandbox.email_username}@${sandbox.email_domain}`,
-        },
-      ],
-    };
+    return buildSuccessResponse(
+      `Email address for sandbox "${sandbox.name}" (ID: ${sandbox.id}) enabled. Address: ${sandbox.email_username}@${sandbox.email_domain}`
+    );
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Failed to enable sandbox email address: ${errorMessage}`,
-        },
-      ],
-      isError: true,
-    };
+    return buildErrorResponse("enable sandbox email address", error);
   }
 }
 

--- a/src/tools/sandbox/enableSandboxEmailAddress.ts
+++ b/src/tools/sandbox/enableSandboxEmailAddress.ts
@@ -1,0 +1,39 @@
+import { requireClient } from "../../client";
+import { SandboxIdRequest } from "../../types/mailtrap";
+
+async function enableSandboxEmailAddress({
+  sandbox_id,
+}: SandboxIdRequest): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    const mailtrap = requireClient("sandboxes");
+
+    const sandbox = await mailtrap.testing.inboxes.enableEmailAddress(
+      sandbox_id
+    );
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Email address for sandbox "${sandbox.name}" (ID: ${sandbox.id}) enabled. Address: ${sandbox.email_username}@${sandbox.email_domain}`,
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to enable sandbox email address: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default enableSandboxEmailAddress;

--- a/src/tools/sandbox/forwardSandboxMessage.ts
+++ b/src/tools/sandbox/forwardSandboxMessage.ts
@@ -1,0 +1,41 @@
+import { getSandboxClient } from "../../client";
+import { ForwardSandboxMessageRequest } from "../../types/mailtrap";
+import resolveSandboxId from "./utils/resolveSandboxId";
+
+async function forwardSandboxMessage({
+  sandbox_id,
+  message_id,
+  email,
+}: ForwardSandboxMessageRequest): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    const sandboxId = resolveSandboxId(sandbox_id);
+    const sandboxClient = getSandboxClient(sandboxId);
+
+    await sandboxClient.testing.messages.forward(sandboxId, message_id, email);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Sandbox message ${message_id} forwarded to ${email}.`,
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to forward sandbox message: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default forwardSandboxMessage;

--- a/src/tools/sandbox/forwardSandboxMessage.ts
+++ b/src/tools/sandbox/forwardSandboxMessage.ts
@@ -1,40 +1,28 @@
 import { getSandboxClient } from "../../client";
 import { ForwardSandboxMessageRequest } from "../../types/mailtrap";
 import resolveSandboxId from "./utils/resolveSandboxId";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
 
 async function forwardSandboxMessage({
   sandbox_id,
   message_id,
   email,
-}: ForwardSandboxMessageRequest): Promise<{
-  content: { type: string; text: string }[];
-  isError?: boolean;
-}> {
+}: ForwardSandboxMessageRequest): Promise<ToolResponse> {
   try {
     const sandboxId = resolveSandboxId(sandbox_id);
     const sandboxClient = getSandboxClient(sandboxId);
 
     await sandboxClient.testing.messages.forward(sandboxId, message_id, email);
 
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Sandbox message ${message_id} forwarded to ${email}.`,
-        },
-      ],
-    };
+    return buildSuccessResponse(
+      `Sandbox message ${message_id} forwarded to ${email}.`
+    );
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Failed to forward sandbox message: ${errorMessage}`,
-        },
-      ],
-      isError: true,
-    };
+    return buildErrorResponse("forward sandbox message", error);
   }
 }
 

--- a/src/tools/sandbox/getSandboxAttachment.ts
+++ b/src/tools/sandbox/getSandboxAttachment.ts
@@ -1,15 +1,17 @@
 import { getSandboxClient } from "../../client";
 import { SandboxAttachmentRequest } from "../../types/mailtrap";
 import resolveSandboxId from "./utils/resolveSandboxId";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
 
 async function getSandboxAttachment({
   sandbox_id,
   message_id,
   attachment_id,
-}: SandboxAttachmentRequest): Promise<{
-  content: { type: string; text: string }[];
-  isError?: boolean;
-}> {
+}: SandboxAttachmentRequest): Promise<ToolResponse> {
   try {
     const sandboxId = resolveSandboxId(sandbox_id);
     const sandboxClient = getSandboxClient(sandboxId);
@@ -20,25 +22,9 @@ async function getSandboxAttachment({
       attachment_id
     );
 
-    return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify(attachment, null, 2),
-        },
-      ],
-    };
+    return buildSuccessResponse(JSON.stringify(attachment, null, 2));
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Failed to get sandbox attachment: ${errorMessage}`,
-        },
-      ],
-      isError: true,
-    };
+    return buildErrorResponse("get sandbox attachment", error);
   }
 }
 

--- a/src/tools/sandbox/getSandboxAttachment.ts
+++ b/src/tools/sandbox/getSandboxAttachment.ts
@@ -1,0 +1,45 @@
+import { getSandboxClient } from "../../client";
+import { SandboxAttachmentRequest } from "../../types/mailtrap";
+import resolveSandboxId from "./utils/resolveSandboxId";
+
+async function getSandboxAttachment({
+  sandbox_id,
+  message_id,
+  attachment_id,
+}: SandboxAttachmentRequest): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    const sandboxId = resolveSandboxId(sandbox_id);
+    const sandboxClient = getSandboxClient(sandboxId);
+
+    const attachment = await sandboxClient.testing.attachments.get(
+      sandboxId,
+      message_id,
+      attachment_id
+    );
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(attachment, null, 2),
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to get sandbox attachment: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default getSandboxAttachment;

--- a/src/tools/sandbox/getSandboxMessageEml.ts
+++ b/src/tools/sandbox/getSandboxMessageEml.ts
@@ -1,0 +1,38 @@
+import { getSandboxClient } from "../../client";
+import { SandboxMessageRequest } from "../../types/mailtrap";
+import resolveSandboxId from "./utils/resolveSandboxId";
+
+async function getSandboxMessageEml({
+  sandbox_id,
+  message_id,
+}: SandboxMessageRequest): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    const sandboxId = resolveSandboxId(sandbox_id);
+    const sandboxClient = getSandboxClient(sandboxId);
+
+    const eml = await sandboxClient.testing.messages.getMessageAsEml(
+      sandboxId,
+      message_id
+    );
+
+    return {
+      content: [{ type: "text", text: eml ?? "" }],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to get sandbox message as EML: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default getSandboxMessageEml;

--- a/src/tools/sandbox/getSandboxMessageEml.ts
+++ b/src/tools/sandbox/getSandboxMessageEml.ts
@@ -1,14 +1,16 @@
 import { getSandboxClient } from "../../client";
 import { SandboxMessageRequest } from "../../types/mailtrap";
 import resolveSandboxId from "./utils/resolveSandboxId";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
 
 async function getSandboxMessageEml({
   sandbox_id,
   message_id,
-}: SandboxMessageRequest): Promise<{
-  content: { type: string; text: string }[];
-  isError?: boolean;
-}> {
+}: SandboxMessageRequest): Promise<ToolResponse> {
   try {
     const sandboxId = resolveSandboxId(sandbox_id);
     const sandboxClient = getSandboxClient(sandboxId);
@@ -18,20 +20,9 @@ async function getSandboxMessageEml({
       message_id
     );
 
-    return {
-      content: [{ type: "text", text: eml ?? "" }],
-    };
+    return buildSuccessResponse(eml ?? "");
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Failed to get sandbox message as EML: ${errorMessage}`,
-        },
-      ],
-      isError: true,
-    };
+    return buildErrorResponse("get sandbox message as EML", error);
   }
 }
 

--- a/src/tools/sandbox/getSandboxMessageHeaders.ts
+++ b/src/tools/sandbox/getSandboxMessageHeaders.ts
@@ -1,0 +1,43 @@
+import { getSandboxClient } from "../../client";
+import { SandboxMessageRequest } from "../../types/mailtrap";
+import resolveSandboxId from "./utils/resolveSandboxId";
+
+async function getSandboxMessageHeaders({
+  sandbox_id,
+  message_id,
+}: SandboxMessageRequest): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    const sandboxId = resolveSandboxId(sandbox_id);
+    const sandboxClient = getSandboxClient(sandboxId);
+
+    const headers = await sandboxClient.testing.messages.getMailHeaders(
+      sandboxId,
+      message_id
+    );
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(headers, null, 2),
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to get sandbox message headers: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default getSandboxMessageHeaders;

--- a/src/tools/sandbox/getSandboxMessageHeaders.ts
+++ b/src/tools/sandbox/getSandboxMessageHeaders.ts
@@ -1,14 +1,16 @@
 import { getSandboxClient } from "../../client";
 import { SandboxMessageRequest } from "../../types/mailtrap";
 import resolveSandboxId from "./utils/resolveSandboxId";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
 
 async function getSandboxMessageHeaders({
   sandbox_id,
   message_id,
-}: SandboxMessageRequest): Promise<{
-  content: { type: string; text: string }[];
-  isError?: boolean;
-}> {
+}: SandboxMessageRequest): Promise<ToolResponse> {
   try {
     const sandboxId = resolveSandboxId(sandbox_id);
     const sandboxClient = getSandboxClient(sandboxId);
@@ -18,25 +20,9 @@ async function getSandboxMessageHeaders({
       message_id
     );
 
-    return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify(headers, null, 2),
-        },
-      ],
-    };
+    return buildSuccessResponse(JSON.stringify(headers, null, 2));
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Failed to get sandbox message headers: ${errorMessage}`,
-        },
-      ],
-      isError: true,
-    };
+    return buildErrorResponse("get sandbox message headers", error);
   }
 }
 

--- a/src/tools/sandbox/getSandboxMessageHtml.ts
+++ b/src/tools/sandbox/getSandboxMessageHtml.ts
@@ -1,0 +1,38 @@
+import { getSandboxClient } from "../../client";
+import { SandboxMessageRequest } from "../../types/mailtrap";
+import resolveSandboxId from "./utils/resolveSandboxId";
+
+async function getSandboxMessageHtml({
+  sandbox_id,
+  message_id,
+}: SandboxMessageRequest): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    const sandboxId = resolveSandboxId(sandbox_id);
+    const sandboxClient = getSandboxClient(sandboxId);
+
+    const html = await sandboxClient.testing.messages.getHtmlMessage(
+      sandboxId,
+      message_id
+    );
+
+    return {
+      content: [{ type: "text", text: html ?? "" }],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to get sandbox message HTML body: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default getSandboxMessageHtml;

--- a/src/tools/sandbox/getSandboxMessageHtml.ts
+++ b/src/tools/sandbox/getSandboxMessageHtml.ts
@@ -1,14 +1,16 @@
 import { getSandboxClient } from "../../client";
 import { SandboxMessageRequest } from "../../types/mailtrap";
 import resolveSandboxId from "./utils/resolveSandboxId";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
 
 async function getSandboxMessageHtml({
   sandbox_id,
   message_id,
-}: SandboxMessageRequest): Promise<{
-  content: { type: string; text: string }[];
-  isError?: boolean;
-}> {
+}: SandboxMessageRequest): Promise<ToolResponse> {
   try {
     const sandboxId = resolveSandboxId(sandbox_id);
     const sandboxClient = getSandboxClient(sandboxId);
@@ -18,20 +20,9 @@ async function getSandboxMessageHtml({
       message_id
     );
 
-    return {
-      content: [{ type: "text", text: html ?? "" }],
-    };
+    return buildSuccessResponse(html ?? "");
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Failed to get sandbox message HTML body: ${errorMessage}`,
-        },
-      ],
-      isError: true,
-    };
+    return buildErrorResponse("get sandbox message HTML body", error);
   }
 }
 

--- a/src/tools/sandbox/getSandboxMessageHtmlAnalysis.ts
+++ b/src/tools/sandbox/getSandboxMessageHtmlAnalysis.ts
@@ -1,14 +1,16 @@
 import { getSandboxClient } from "../../client";
 import { SandboxMessageRequest } from "../../types/mailtrap";
 import resolveSandboxId from "./utils/resolveSandboxId";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
 
 async function getSandboxMessageHtmlAnalysis({
   sandbox_id,
   message_id,
-}: SandboxMessageRequest): Promise<{
-  content: { type: string; text: string }[];
-  isError?: boolean;
-}> {
+}: SandboxMessageRequest): Promise<ToolResponse> {
   try {
     const sandboxId = resolveSandboxId(sandbox_id);
     const sandboxClient = getSandboxClient(sandboxId);
@@ -18,25 +20,9 @@ async function getSandboxMessageHtmlAnalysis({
       message_id
     );
 
-    return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify(analysis, null, 2),
-        },
-      ],
-    };
+    return buildSuccessResponse(JSON.stringify(analysis, null, 2));
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Failed to get sandbox message HTML analysis: ${errorMessage}`,
-        },
-      ],
-      isError: true,
-    };
+    return buildErrorResponse("get sandbox message HTML analysis", error);
   }
 }
 

--- a/src/tools/sandbox/getSandboxMessageHtmlAnalysis.ts
+++ b/src/tools/sandbox/getSandboxMessageHtmlAnalysis.ts
@@ -1,0 +1,43 @@
+import { getSandboxClient } from "../../client";
+import { SandboxMessageRequest } from "../../types/mailtrap";
+import resolveSandboxId from "./utils/resolveSandboxId";
+
+async function getSandboxMessageHtmlAnalysis({
+  sandbox_id,
+  message_id,
+}: SandboxMessageRequest): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    const sandboxId = resolveSandboxId(sandbox_id);
+    const sandboxClient = getSandboxClient(sandboxId);
+
+    const analysis = await sandboxClient.testing.messages.getHtmlAnalysis(
+      sandboxId,
+      message_id
+    );
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(analysis, null, 2),
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to get sandbox message HTML analysis: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default getSandboxMessageHtmlAnalysis;

--- a/src/tools/sandbox/getSandboxMessageHtmlSource.ts
+++ b/src/tools/sandbox/getSandboxMessageHtmlSource.ts
@@ -1,14 +1,16 @@
 import { getSandboxClient } from "../../client";
 import { SandboxMessageRequest } from "../../types/mailtrap";
 import resolveSandboxId from "./utils/resolveSandboxId";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
 
 async function getSandboxMessageHtmlSource({
   sandbox_id,
   message_id,
-}: SandboxMessageRequest): Promise<{
-  content: { type: string; text: string }[];
-  isError?: boolean;
-}> {
+}: SandboxMessageRequest): Promise<ToolResponse> {
   try {
     const sandboxId = resolveSandboxId(sandbox_id);
     const sandboxClient = getSandboxClient(sandboxId);
@@ -18,20 +20,9 @@ async function getSandboxMessageHtmlSource({
       message_id
     );
 
-    return {
-      content: [{ type: "text", text: source ?? "" }],
-    };
+    return buildSuccessResponse(source ?? "");
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Failed to get sandbox message HTML source: ${errorMessage}`,
-        },
-      ],
-      isError: true,
-    };
+    return buildErrorResponse("get sandbox message HTML source", error);
   }
 }
 

--- a/src/tools/sandbox/getSandboxMessageHtmlSource.ts
+++ b/src/tools/sandbox/getSandboxMessageHtmlSource.ts
@@ -1,0 +1,38 @@
+import { getSandboxClient } from "../../client";
+import { SandboxMessageRequest } from "../../types/mailtrap";
+import resolveSandboxId from "./utils/resolveSandboxId";
+
+async function getSandboxMessageHtmlSource({
+  sandbox_id,
+  message_id,
+}: SandboxMessageRequest): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    const sandboxId = resolveSandboxId(sandbox_id);
+    const sandboxClient = getSandboxClient(sandboxId);
+
+    const source = await sandboxClient.testing.messages.getMessageHtmlSource(
+      sandboxId,
+      message_id
+    );
+
+    return {
+      content: [{ type: "text", text: source ?? "" }],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to get sandbox message HTML source: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default getSandboxMessageHtmlSource;

--- a/src/tools/sandbox/getSandboxMessageRaw.ts
+++ b/src/tools/sandbox/getSandboxMessageRaw.ts
@@ -1,14 +1,16 @@
 import { getSandboxClient } from "../../client";
 import { SandboxMessageRequest } from "../../types/mailtrap";
 import resolveSandboxId from "./utils/resolveSandboxId";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
 
 async function getSandboxMessageRaw({
   sandbox_id,
   message_id,
-}: SandboxMessageRequest): Promise<{
-  content: { type: string; text: string }[];
-  isError?: boolean;
-}> {
+}: SandboxMessageRequest): Promise<ToolResponse> {
   try {
     const sandboxId = resolveSandboxId(sandbox_id);
     const sandboxClient = getSandboxClient(sandboxId);
@@ -18,20 +20,9 @@ async function getSandboxMessageRaw({
       message_id
     );
 
-    return {
-      content: [{ type: "text", text: raw ?? "" }],
-    };
+    return buildSuccessResponse(raw ?? "");
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Failed to get sandbox message raw body: ${errorMessage}`,
-        },
-      ],
-      isError: true,
-    };
+    return buildErrorResponse("get sandbox message raw body", error);
   }
 }
 

--- a/src/tools/sandbox/getSandboxMessageRaw.ts
+++ b/src/tools/sandbox/getSandboxMessageRaw.ts
@@ -1,0 +1,38 @@
+import { getSandboxClient } from "../../client";
+import { SandboxMessageRequest } from "../../types/mailtrap";
+import resolveSandboxId from "./utils/resolveSandboxId";
+
+async function getSandboxMessageRaw({
+  sandbox_id,
+  message_id,
+}: SandboxMessageRequest): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    const sandboxId = resolveSandboxId(sandbox_id);
+    const sandboxClient = getSandboxClient(sandboxId);
+
+    const raw = await sandboxClient.testing.messages.getRawMessage(
+      sandboxId,
+      message_id
+    );
+
+    return {
+      content: [{ type: "text", text: raw ?? "" }],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to get sandbox message raw body: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default getSandboxMessageRaw;

--- a/src/tools/sandbox/getSandboxMessageSpamScore.ts
+++ b/src/tools/sandbox/getSandboxMessageSpamScore.ts
@@ -1,0 +1,43 @@
+import { getSandboxClient } from "../../client";
+import { SandboxMessageRequest } from "../../types/mailtrap";
+import resolveSandboxId from "./utils/resolveSandboxId";
+
+async function getSandboxMessageSpamScore({
+  sandbox_id,
+  message_id,
+}: SandboxMessageRequest): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    const sandboxId = resolveSandboxId(sandbox_id);
+    const sandboxClient = getSandboxClient(sandboxId);
+
+    const report = await sandboxClient.testing.messages.getSpamScore(
+      sandboxId,
+      message_id
+    );
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(report, null, 2),
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to get sandbox message spam score: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default getSandboxMessageSpamScore;

--- a/src/tools/sandbox/getSandboxMessageSpamScore.ts
+++ b/src/tools/sandbox/getSandboxMessageSpamScore.ts
@@ -1,14 +1,16 @@
 import { getSandboxClient } from "../../client";
 import { SandboxMessageRequest } from "../../types/mailtrap";
 import resolveSandboxId from "./utils/resolveSandboxId";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
 
 async function getSandboxMessageSpamScore({
   sandbox_id,
   message_id,
-}: SandboxMessageRequest): Promise<{
-  content: { type: string; text: string }[];
-  isError?: boolean;
-}> {
+}: SandboxMessageRequest): Promise<ToolResponse> {
   try {
     const sandboxId = resolveSandboxId(sandbox_id);
     const sandboxClient = getSandboxClient(sandboxId);
@@ -18,25 +20,9 @@ async function getSandboxMessageSpamScore({
       message_id
     );
 
-    return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify(report, null, 2),
-        },
-      ],
-    };
+    return buildSuccessResponse(JSON.stringify(report, null, 2));
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Failed to get sandbox message spam score: ${errorMessage}`,
-        },
-      ],
-      isError: true,
-    };
+    return buildErrorResponse("get sandbox message spam score", error);
   }
 }
 

--- a/src/tools/sandbox/getSandboxMessageText.ts
+++ b/src/tools/sandbox/getSandboxMessageText.ts
@@ -1,14 +1,16 @@
 import { getSandboxClient } from "../../client";
 import { SandboxMessageRequest } from "../../types/mailtrap";
 import resolveSandboxId from "./utils/resolveSandboxId";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
 
 async function getSandboxMessageText({
   sandbox_id,
   message_id,
-}: SandboxMessageRequest): Promise<{
-  content: { type: string; text: string }[];
-  isError?: boolean;
-}> {
+}: SandboxMessageRequest): Promise<ToolResponse> {
   try {
     const sandboxId = resolveSandboxId(sandbox_id);
     const sandboxClient = getSandboxClient(sandboxId);
@@ -18,20 +20,9 @@ async function getSandboxMessageText({
       message_id
     );
 
-    return {
-      content: [{ type: "text", text: text ?? "" }],
-    };
+    return buildSuccessResponse(text ?? "");
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Failed to get sandbox message text body: ${errorMessage}`,
-        },
-      ],
-      isError: true,
-    };
+    return buildErrorResponse("get sandbox message text body", error);
   }
 }
 

--- a/src/tools/sandbox/getSandboxMessageText.ts
+++ b/src/tools/sandbox/getSandboxMessageText.ts
@@ -1,0 +1,38 @@
+import { getSandboxClient } from "../../client";
+import { SandboxMessageRequest } from "../../types/mailtrap";
+import resolveSandboxId from "./utils/resolveSandboxId";
+
+async function getSandboxMessageText({
+  sandbox_id,
+  message_id,
+}: SandboxMessageRequest): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    const sandboxId = resolveSandboxId(sandbox_id);
+    const sandboxClient = getSandboxClient(sandboxId);
+
+    const text = await sandboxClient.testing.messages.getTextMessage(
+      sandboxId,
+      message_id
+    );
+
+    return {
+      content: [{ type: "text", text: text ?? "" }],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to get sandbox message text body: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default getSandboxMessageText;

--- a/src/tools/sandbox/index.ts
+++ b/src/tools/sandbox/index.ts
@@ -25,6 +25,36 @@ import deleteSandboxInbox from "./deleteSandboxInbox";
 import cleanSandboxInboxSchema from "./schemas/cleanSandboxInbox";
 import cleanSandboxInbox from "./cleanSandboxInbox";
 
+// Sandbox management additions
+import listSandboxesSchema from "./schemas/listSandboxes";
+import listSandboxes from "./listSandboxes";
+import sandboxActionSchema from "./schemas/sandboxAction";
+import markSandboxAsRead from "./markSandboxAsRead";
+import resetSandboxCredentials from "./resetSandboxCredentials";
+import enableSandboxEmailAddress from "./enableSandboxEmailAddress";
+import resetSandboxEmailAddress from "./resetSandboxEmailAddress";
+
+// Message management additions
+import sandboxMessageSchema from "./schemas/sandboxMessage";
+import forwardSandboxMessageSchema from "./schemas/forwardSandboxMessage";
+import updateSandboxMessageSchema from "./schemas/updateSandboxMessage";
+import forwardSandboxMessage from "./forwardSandboxMessage";
+import updateSandboxMessage from "./updateSandboxMessage";
+import deleteSandboxMessage from "./deleteSandboxMessage";
+import getSandboxMessageSpamScore from "./getSandboxMessageSpamScore";
+import getSandboxMessageHtmlAnalysis from "./getSandboxMessageHtmlAnalysis";
+import getSandboxMessageHeaders from "./getSandboxMessageHeaders";
+import getSandboxMessageHtml from "./getSandboxMessageHtml";
+import getSandboxMessageText from "./getSandboxMessageText";
+import getSandboxMessageRaw from "./getSandboxMessageRaw";
+import getSandboxMessageEml from "./getSandboxMessageEml";
+import getSandboxMessageHtmlSource from "./getSandboxMessageHtmlSource";
+
+// Attachment additions
+import getSandboxAttachmentSchema from "./schemas/getSandboxAttachment";
+import listSandboxAttachments from "./listSandboxAttachments";
+import getSandboxAttachment from "./getSandboxAttachment";
+
 export {
   sendSandboxEmailSchema,
   sendSandboxEmail,
@@ -52,4 +82,31 @@ export {
   deleteSandboxInbox,
   cleanSandboxInboxSchema,
   cleanSandboxInbox,
+  // Sandbox management additions
+  listSandboxesSchema,
+  listSandboxes,
+  sandboxActionSchema,
+  markSandboxAsRead,
+  resetSandboxCredentials,
+  enableSandboxEmailAddress,
+  resetSandboxEmailAddress,
+  // Message management additions
+  sandboxMessageSchema,
+  forwardSandboxMessageSchema,
+  updateSandboxMessageSchema,
+  forwardSandboxMessage,
+  updateSandboxMessage,
+  deleteSandboxMessage,
+  getSandboxMessageSpamScore,
+  getSandboxMessageHtmlAnalysis,
+  getSandboxMessageHeaders,
+  getSandboxMessageHtml,
+  getSandboxMessageText,
+  getSandboxMessageRaw,
+  getSandboxMessageEml,
+  getSandboxMessageHtmlSource,
+  // Attachment additions
+  getSandboxAttachmentSchema,
+  listSandboxAttachments,
+  getSandboxAttachment,
 };

--- a/src/tools/sandbox/listSandboxAttachments.ts
+++ b/src/tools/sandbox/listSandboxAttachments.ts
@@ -1,0 +1,63 @@
+import { getSandboxClient } from "../../client";
+import { SandboxMessageRequest } from "../../types/mailtrap";
+import resolveSandboxId from "./utils/resolveSandboxId";
+
+async function listSandboxAttachments({
+  sandbox_id,
+  message_id,
+}: SandboxMessageRequest): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    const sandboxId = resolveSandboxId(sandbox_id);
+    const sandboxClient = getSandboxClient(sandboxId);
+
+    const attachments = await sandboxClient.testing.attachments.getList(
+      sandboxId,
+      message_id
+    );
+
+    if (!attachments || attachments.length === 0) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `No attachments on sandbox message ${message_id}.`,
+          },
+        ],
+      };
+    }
+
+    const lines = attachments.map(
+      (att: any) =>
+        `• ${att.filename} (ID: ${att.id}, type: ${
+          att.content_type ?? "?"
+        }, size: ${att.attachment_size ?? "?"} bytes)`
+    );
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Attachments on sandbox message ${message_id} (${
+            attachments.length
+          }):\n\n${lines.join("\n")}`,
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to list sandbox attachments: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default listSandboxAttachments;

--- a/src/tools/sandbox/listSandboxAttachments.ts
+++ b/src/tools/sandbox/listSandboxAttachments.ts
@@ -1,14 +1,16 @@
 import { getSandboxClient } from "../../client";
 import { SandboxMessageRequest } from "../../types/mailtrap";
 import resolveSandboxId from "./utils/resolveSandboxId";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
 
 async function listSandboxAttachments({
   sandbox_id,
   message_id,
-}: SandboxMessageRequest): Promise<{
-  content: { type: string; text: string }[];
-  isError?: boolean;
-}> {
+}: SandboxMessageRequest): Promise<ToolResponse> {
   try {
     const sandboxId = resolveSandboxId(sandbox_id);
     const sandboxClient = getSandboxClient(sandboxId);
@@ -19,14 +21,9 @@ async function listSandboxAttachments({
     );
 
     if (!attachments || attachments.length === 0) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `No attachments on sandbox message ${message_id}.`,
-          },
-        ],
-      };
+      return buildSuccessResponse(
+        `No attachments on sandbox message ${message_id}.`
+      );
     }
 
     const lines = attachments.map(
@@ -36,27 +33,13 @@ async function listSandboxAttachments({
         }, size: ${att.attachment_size ?? "?"} bytes)`
     );
 
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Attachments on sandbox message ${message_id} (${
-            attachments.length
-          }):\n\n${lines.join("\n")}`,
-        },
-      ],
-    };
+    return buildSuccessResponse(
+      `Attachments on sandbox message ${message_id} (${
+        attachments.length
+      }):\n\n${lines.join("\n")}`
+    );
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Failed to list sandbox attachments: ${errorMessage}`,
-        },
-      ],
-      isError: true,
-    };
+    return buildErrorResponse("list sandbox attachments", error);
   }
 }
 

--- a/src/tools/sandbox/listSandboxes.ts
+++ b/src/tools/sandbox/listSandboxes.ts
@@ -1,23 +1,20 @@
 import { requireClient } from "../../client";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
 
-async function listSandboxes(): Promise<{
-  content: { type: string; text: string }[];
-  isError?: boolean;
-}> {
+async function listSandboxes(): Promise<ToolResponse> {
   try {
     const mailtrap = requireClient("sandboxes");
 
     const sandboxes = await mailtrap.testing.inboxes.getList();
 
     if (!sandboxes || sandboxes.length === 0) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: "No sandboxes found in your Mailtrap account.",
-          },
-        ],
-      };
+      return buildSuccessResponse(
+        "No sandboxes found in your Mailtrap account."
+      );
     }
 
     const lines = sandboxes.map(
@@ -27,25 +24,11 @@ async function listSandboxes(): Promise<{
         }, emails: ${sandbox.emails_count ?? 0})`
     );
 
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Sandboxes (${sandboxes.length}):\n\n${lines.join("\n")}`,
-        },
-      ],
-    };
+    return buildSuccessResponse(
+      `Sandboxes (${sandboxes.length}):\n\n${lines.join("\n")}`
+    );
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Failed to list sandboxes: ${errorMessage}`,
-        },
-      ],
-      isError: true,
-    };
+    return buildErrorResponse("list sandboxes", error);
   }
 }
 

--- a/src/tools/sandbox/listSandboxes.ts
+++ b/src/tools/sandbox/listSandboxes.ts
@@ -1,0 +1,52 @@
+import { requireClient } from "../../client";
+
+async function listSandboxes(): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    const mailtrap = requireClient("sandboxes");
+
+    const sandboxes = await mailtrap.testing.inboxes.getList();
+
+    if (!sandboxes || sandboxes.length === 0) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: "No sandboxes found in your Mailtrap account.",
+          },
+        ],
+      };
+    }
+
+    const lines = sandboxes.map(
+      (sandbox: any) =>
+        `• ${sandbox.name} (ID: ${sandbox.id}, project: ${
+          sandbox.project_id ?? "?"
+        }, emails: ${sandbox.emails_count ?? 0})`
+    );
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Sandboxes (${sandboxes.length}):\n\n${lines.join("\n")}`,
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to list sandboxes: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default listSandboxes;

--- a/src/tools/sandbox/markSandboxAsRead.ts
+++ b/src/tools/sandbox/markSandboxAsRead.ts
@@ -1,0 +1,35 @@
+import { requireClient } from "../../client";
+import { SandboxIdRequest } from "../../types/mailtrap";
+
+async function markSandboxAsRead({ sandbox_id }: SandboxIdRequest): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    const mailtrap = requireClient("sandboxes");
+
+    const sandbox = await mailtrap.testing.inboxes.markAsRead(sandbox_id);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Marked all messages in sandbox "${sandbox.name}" (ID: ${sandbox.id}) as read.`,
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to mark sandbox as read: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default markSandboxAsRead;

--- a/src/tools/sandbox/markSandboxAsRead.ts
+++ b/src/tools/sandbox/markSandboxAsRead.ts
@@ -1,34 +1,24 @@
 import { requireClient } from "../../client";
 import { SandboxIdRequest } from "../../types/mailtrap";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
 
-async function markSandboxAsRead({ sandbox_id }: SandboxIdRequest): Promise<{
-  content: { type: string; text: string }[];
-  isError?: boolean;
-}> {
+async function markSandboxAsRead({
+  sandbox_id,
+}: SandboxIdRequest): Promise<ToolResponse> {
   try {
     const mailtrap = requireClient("sandboxes");
 
     const sandbox = await mailtrap.testing.inboxes.markAsRead(sandbox_id);
 
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Marked all messages in sandbox "${sandbox.name}" (ID: ${sandbox.id}) as read.`,
-        },
-      ],
-    };
+    return buildSuccessResponse(
+      `Marked all messages in sandbox "${sandbox.name}" (ID: ${sandbox.id}) as read.`
+    );
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Failed to mark sandbox as read: ${errorMessage}`,
-        },
-      ],
-      isError: true,
-    };
+    return buildErrorResponse("mark sandbox as read", error);
   }
 }
 

--- a/src/tools/sandbox/resetSandboxCredentials.ts
+++ b/src/tools/sandbox/resetSandboxCredentials.ts
@@ -1,0 +1,41 @@
+import { requireClient } from "../../client";
+import { SandboxIdRequest } from "../../types/mailtrap";
+
+async function resetSandboxCredentials({
+  sandbox_id,
+}: SandboxIdRequest): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    const mailtrap = requireClient("sandboxes");
+
+    const sandbox = await mailtrap.testing.inboxes.resetCredentials(sandbox_id);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: [
+            `SMTP credentials for sandbox "${sandbox.name}" (ID: ${sandbox.id}) have been reset.`,
+            `Username: ${sandbox.username}`,
+            `Password: ${sandbox.password}`,
+          ].join("\n"),
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to reset sandbox credentials: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default resetSandboxCredentials;

--- a/src/tools/sandbox/resetSandboxCredentials.ts
+++ b/src/tools/sandbox/resetSandboxCredentials.ts
@@ -1,40 +1,28 @@
 import { requireClient } from "../../client";
 import { SandboxIdRequest } from "../../types/mailtrap";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
 
 async function resetSandboxCredentials({
   sandbox_id,
-}: SandboxIdRequest): Promise<{
-  content: { type: string; text: string }[];
-  isError?: boolean;
-}> {
+}: SandboxIdRequest): Promise<ToolResponse> {
   try {
     const mailtrap = requireClient("sandboxes");
 
     const sandbox = await mailtrap.testing.inboxes.resetCredentials(sandbox_id);
 
-    return {
-      content: [
-        {
-          type: "text",
-          text: [
-            `SMTP credentials for sandbox "${sandbox.name}" (ID: ${sandbox.id}) have been reset.`,
-            `Username: ${sandbox.username}`,
-            `Password: ${sandbox.password}`,
-          ].join("\n"),
-        },
-      ],
-    };
+    return buildSuccessResponse(
+      [
+        `SMTP credentials for sandbox "${sandbox.name}" (ID: ${sandbox.id}) have been reset.`,
+        `Username: ${sandbox.username}`,
+        `Password: ${sandbox.password}`,
+      ].join("\n")
+    );
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Failed to reset sandbox credentials: ${errorMessage}`,
-        },
-      ],
-      isError: true,
-    };
+    return buildErrorResponse("reset sandbox credentials", error);
   }
 }
 

--- a/src/tools/sandbox/resetSandboxEmailAddress.ts
+++ b/src/tools/sandbox/resetSandboxEmailAddress.ts
@@ -1,12 +1,14 @@
 import { requireClient } from "../../client";
 import { SandboxIdRequest } from "../../types/mailtrap";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
 
 async function resetSandboxEmailAddress({
   sandbox_id,
-}: SandboxIdRequest): Promise<{
-  content: { type: string; text: string }[];
-  isError?: boolean;
-}> {
+}: SandboxIdRequest): Promise<ToolResponse> {
   try {
     const mailtrap = requireClient("sandboxes");
 
@@ -14,25 +16,11 @@ async function resetSandboxEmailAddress({
       sandbox_id
     );
 
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Email address for sandbox "${sandbox.name}" (ID: ${sandbox.id}) reset. New address: ${sandbox.email_username}@${sandbox.email_domain}`,
-        },
-      ],
-    };
+    return buildSuccessResponse(
+      `Email address for sandbox "${sandbox.name}" (ID: ${sandbox.id}) reset. New address: ${sandbox.email_username}@${sandbox.email_domain}`
+    );
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Failed to reset sandbox email address: ${errorMessage}`,
-        },
-      ],
-      isError: true,
-    };
+    return buildErrorResponse("reset sandbox email address", error);
   }
 }
 

--- a/src/tools/sandbox/resetSandboxEmailAddress.ts
+++ b/src/tools/sandbox/resetSandboxEmailAddress.ts
@@ -1,0 +1,39 @@
+import { requireClient } from "../../client";
+import { SandboxIdRequest } from "../../types/mailtrap";
+
+async function resetSandboxEmailAddress({
+  sandbox_id,
+}: SandboxIdRequest): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    const mailtrap = requireClient("sandboxes");
+
+    const sandbox = await mailtrap.testing.inboxes.resetEmailAddress(
+      sandbox_id
+    );
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Email address for sandbox "${sandbox.name}" (ID: ${sandbox.id}) reset. New address: ${sandbox.email_username}@${sandbox.email_domain}`,
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to reset sandbox email address: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default resetSandboxEmailAddress;

--- a/src/tools/sandbox/schemas/forwardSandboxMessage.ts
+++ b/src/tools/sandbox/schemas/forwardSandboxMessage.ts
@@ -1,0 +1,23 @@
+const forwardSandboxMessageSchema = {
+  type: "object",
+  properties: {
+    sandbox_id: {
+      type: "number",
+      description:
+        "Sandbox ID. Falls back to MAILTRAP_SANDBOX_ID env var if omitted.",
+    },
+    message_id: {
+      type: "number",
+      description: "ID of the sandbox message to forward",
+    },
+    email: {
+      type: "string",
+      description: "Email address to forward the message to",
+      format: "email",
+    },
+  },
+  required: ["message_id", "email"],
+  additionalProperties: false,
+};
+
+export default forwardSandboxMessageSchema;

--- a/src/tools/sandbox/schemas/getSandboxAttachment.ts
+++ b/src/tools/sandbox/schemas/getSandboxAttachment.ts
@@ -1,0 +1,22 @@
+const getSandboxAttachmentSchema = {
+  type: "object",
+  properties: {
+    sandbox_id: {
+      type: "number",
+      description:
+        "Sandbox ID. Falls back to MAILTRAP_SANDBOX_ID env var if omitted.",
+    },
+    message_id: {
+      type: "number",
+      description: "ID of the sandbox message that contains the attachment",
+    },
+    attachment_id: {
+      type: "number",
+      description: "ID of the attachment to fetch",
+    },
+  },
+  required: ["message_id", "attachment_id"],
+  additionalProperties: false,
+};
+
+export default getSandboxAttachmentSchema;

--- a/src/tools/sandbox/schemas/listSandboxes.ts
+++ b/src/tools/sandbox/schemas/listSandboxes.ts
@@ -1,0 +1,7 @@
+const listSandboxesSchema = {
+  type: "object",
+  properties: {},
+  additionalProperties: false,
+};
+
+export default listSandboxesSchema;

--- a/src/tools/sandbox/schemas/sandboxAction.ts
+++ b/src/tools/sandbox/schemas/sandboxAction.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared input schema for sandbox-scoped actions that take only `sandbox_id`
+ * (mark-as-read, reset-credentials, enable-email-address, reset-email-address).
+ */
+const sandboxActionSchema = {
+  type: "object",
+  properties: {
+    sandbox_id: {
+      type: "number",
+      description: "ID of the sandbox to act on",
+    },
+  },
+  required: ["sandbox_id"],
+  additionalProperties: false,
+};
+
+export default sandboxActionSchema;

--- a/src/tools/sandbox/schemas/sandboxMessage.ts
+++ b/src/tools/sandbox/schemas/sandboxMessage.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared input schema for message-scoped sandbox tools that take only
+ * `sandbox_id` (optional, env fallback) and `message_id`.
+ * Used by: delete, spam-score, html-analysis, headers, html, text, raw, eml,
+ * html-source, list-attachments.
+ */
+const sandboxMessageSchema = {
+  type: "object",
+  properties: {
+    sandbox_id: {
+      type: "number",
+      description:
+        "Sandbox ID. Falls back to MAILTRAP_SANDBOX_ID env var if omitted.",
+    },
+    message_id: {
+      type: "number",
+      description: "ID of the sandbox message",
+    },
+  },
+  required: ["message_id"],
+  additionalProperties: false,
+};
+
+export default sandboxMessageSchema;

--- a/src/tools/sandbox/schemas/updateSandboxMessage.ts
+++ b/src/tools/sandbox/schemas/updateSandboxMessage.ts
@@ -1,0 +1,22 @@
+const updateSandboxMessageSchema = {
+  type: "object",
+  properties: {
+    sandbox_id: {
+      type: "number",
+      description:
+        "Sandbox ID. Falls back to MAILTRAP_SANDBOX_ID env var if omitted.",
+    },
+    message_id: {
+      type: "number",
+      description: "ID of the sandbox message to update",
+    },
+    is_read: {
+      type: "boolean",
+      description: "Mark the message as read (true) or unread (false)",
+    },
+  },
+  required: ["message_id", "is_read"],
+  additionalProperties: false,
+};
+
+export default updateSandboxMessageSchema;

--- a/src/tools/sandbox/updateSandboxMessage.ts
+++ b/src/tools/sandbox/updateSandboxMessage.ts
@@ -1,15 +1,17 @@
 import { getSandboxClient } from "../../client";
 import { UpdateSandboxMessageRequest } from "../../types/mailtrap";
 import resolveSandboxId from "./utils/resolveSandboxId";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
 
 async function updateSandboxMessage({
   sandbox_id,
   message_id,
   is_read,
-}: UpdateSandboxMessageRequest): Promise<{
-  content: { type: string; text: string }[];
-  isError?: boolean;
-}> {
+}: UpdateSandboxMessageRequest): Promise<ToolResponse> {
   try {
     const sandboxId = resolveSandboxId(sandbox_id);
     const sandboxClient = getSandboxClient(sandboxId);
@@ -20,27 +22,13 @@ async function updateSandboxMessage({
       { isRead: is_read }
     );
 
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Sandbox message ${message.id} marked as ${
-            message.is_read ? "read" : "unread"
-          }.`,
-        },
-      ],
-    };
+    return buildSuccessResponse(
+      `Sandbox message ${message.id} marked as ${
+        message.is_read ? "read" : "unread"
+      }.`
+    );
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Failed to update sandbox message: ${errorMessage}`,
-        },
-      ],
-      isError: true,
-    };
+    return buildErrorResponse("update sandbox message", error);
   }
 }
 

--- a/src/tools/sandbox/updateSandboxMessage.ts
+++ b/src/tools/sandbox/updateSandboxMessage.ts
@@ -1,0 +1,47 @@
+import { getSandboxClient } from "../../client";
+import { UpdateSandboxMessageRequest } from "../../types/mailtrap";
+import resolveSandboxId from "./utils/resolveSandboxId";
+
+async function updateSandboxMessage({
+  sandbox_id,
+  message_id,
+  is_read,
+}: UpdateSandboxMessageRequest): Promise<{
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}> {
+  try {
+    const sandboxId = resolveSandboxId(sandbox_id);
+    const sandboxClient = getSandboxClient(sandboxId);
+
+    const message = await sandboxClient.testing.messages.updateMessage(
+      sandboxId,
+      message_id,
+      { isRead: is_read }
+    );
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Sandbox message ${message.id} marked as ${
+            message.is_read ? "read" : "unread"
+          }.`,
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Failed to update sandbox message: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export default updateSandboxMessage;

--- a/src/tools/sandbox/utils/resolveSandboxId.ts
+++ b/src/tools/sandbox/utils/resolveSandboxId.ts
@@ -1,0 +1,26 @@
+/**
+ * Resolve a sandbox ID from a tool argument, falling back to the
+ * MAILTRAP_SANDBOX_ID environment variable (or the legacy MAILTRAP_TEST_INBOX_ID
+ * env var, kept for backward compatibility). Throws if neither is set or if
+ * the resolved value is not a finite number.
+ */
+function resolveSandboxId(sandboxId: number | undefined): number {
+  const raw =
+    sandboxId ??
+    process.env.MAILTRAP_SANDBOX_ID ??
+    process.env.MAILTRAP_TEST_INBOX_ID;
+  if (raw === undefined || raw === null || raw === "") {
+    throw new Error(
+      "Provide sandbox_id or set MAILTRAP_SANDBOX_ID environment variable for sandbox mode"
+    );
+  }
+  const resolved = Number(raw);
+  if (!Number.isFinite(resolved)) {
+    throw new Error(
+      "sandbox_id (or MAILTRAP_SANDBOX_ID) must be a valid number"
+    );
+  }
+  return resolved;
+}
+
+export default resolveSandboxId;

--- a/src/tools/utils/__tests__/responses.test.ts
+++ b/src/tools/utils/__tests__/responses.test.ts
@@ -1,0 +1,71 @@
+import { buildErrorResponse, buildSuccessResponse } from "../responses";
+
+describe("buildSuccessResponse", () => {
+  it("wraps text into a single content item", () => {
+    const result = buildSuccessResponse("Done.");
+
+    expect(result).toEqual({
+      content: [{ type: "text", text: "Done." }],
+    });
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("preserves empty strings", () => {
+    const result = buildSuccessResponse("");
+
+    expect(result.content).toEqual([{ type: "text", text: "" }]);
+  });
+
+  it("preserves multi-line text verbatim", () => {
+    const multiline = "Line 1\nLine 2\nLine 3";
+
+    const result = buildSuccessResponse(multiline);
+
+    expect(result.content[0].text).toBe(multiline);
+  });
+});
+
+describe("buildErrorResponse", () => {
+  it("formats Error instances using their message", () => {
+    const result = buildErrorResponse(
+      "do thing",
+      new Error("something exploded")
+    );
+
+    expect(result).toEqual({
+      content: [
+        { type: "text", text: "Failed to do thing: something exploded" },
+      ],
+      isError: true,
+    });
+  });
+
+  it("coerces non-Error values via String()", () => {
+    const result = buildErrorResponse("do thing", "raw string failure");
+
+    expect(result.content[0].text).toBe(
+      "Failed to do thing: raw string failure"
+    );
+    expect(result.isError).toBe(true);
+  });
+
+  it("handles null and undefined errors", () => {
+    expect(buildErrorResponse("do thing", null).content[0].text).toBe(
+      "Failed to do thing: null"
+    );
+    expect(buildErrorResponse("do thing", undefined).content[0].text).toBe(
+      "Failed to do thing: undefined"
+    );
+  });
+
+  it("interpolates the action verb into the message", () => {
+    const result = buildErrorResponse(
+      "list sandboxes",
+      new Error("network down")
+    );
+
+    expect(result.content[0].text).toBe(
+      "Failed to list sandboxes: network down"
+    );
+  });
+});

--- a/src/tools/utils/responses.ts
+++ b/src/tools/utils/responses.ts
@@ -1,0 +1,21 @@
+export interface ToolResponse {
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}
+
+export function buildSuccessResponse(text: string): ToolResponse {
+  return {
+    content: [{ type: "text", text }],
+  };
+}
+
+export function buildErrorResponse(
+  action: string,
+  error: unknown
+): ToolResponse {
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  return {
+    content: [{ type: "text", text: `Failed to ${action}: ${errorMessage}` }],
+    isError: true,
+  };
+}

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -229,6 +229,29 @@ export interface DeleteSandboxInboxRequest {
   inbox_id: number;
 }
 
+/** Common shape for sandbox-scoped actions identified by sandbox_id only. */
+export interface SandboxIdRequest {
+  sandbox_id: number;
+}
+
+/** Common shape for message-scoped sandbox actions. `sandbox_id` is optional; falls back to env. */
+export interface SandboxMessageRequest {
+  sandbox_id?: number;
+  message_id: number;
+}
+
+export interface ForwardSandboxMessageRequest extends SandboxMessageRequest {
+  email: string;
+}
+
+export interface UpdateSandboxMessageRequest extends SandboxMessageRequest {
+  is_read: boolean;
+}
+
+export interface SandboxAttachmentRequest extends SandboxMessageRequest {
+  attachment_id: number;
+}
+
 export interface CleanSandboxInboxRequest {
   inbox_id: number;
 }


### PR DESCRIPTION
## Motivation

Cover missing endpoints with MCP tools

## Changes

Sandbox management (5)
  - list-sandboxes
  - mark-sandbox-as-read
  - reset-sandbox-credentials
  - enable-sandbox-email-address
  - reset-sandbox-email-address
  
  Message mutations (3)
  - forward-sandbox-message
  - update-sandbox-message
  - delete-sandbox-message
  
  Message inspection (8)
  - get-sandbox-message-spam-score
  - get-sandbox-message-html-analysis
  - get-sandbox-message-headers
  - get-sandbox-message-html
  - get-sandbox-message-text
  - get-sandbox-message-raw
  - get-sandbox-message-eml
  - get-sandbox-message-html-source

  Attachments (2)
  - list-sandbox-attachments
  - get-sandbox-attachment
