### PR TITLE
Add missing contact field tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,5 +150,6 @@ Schema files define a JSON Schema–shaped object for MCP; optional Zod schemas 
 #### Contact Fields
 
 - **list-contact-fields**: List all contact field definitions for the account.
+- **get-contact-field**: Get a contact field definition by ID.
 
 Tools use input schemas (JSON Schema format) for MCP; handlers may validate input with Zod. Response format follows the MCP protocol.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,5 +153,6 @@ Schema files define a JSON Schema–shaped object for MCP; optional Zod schemas 
 - **get-contact-field**: Get a contact field definition by ID.
 - **create-contact-field**: Create a new contact field. Requires `name`, unique `merge_tag`, and `data_type` (text/number/boolean/date).
 - **update-contact-field**: Update name, merge_tag, or data_type of an existing contact field.
+- **delete-contact-field**: Permanently delete a contact field by ID.
 
 Tools use input schemas (JSON Schema format) for MCP; handlers may validate input with Zod. Response format follows the MCP protocol.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,5 +151,6 @@ Schema files define a JSON Schema–shaped object for MCP; optional Zod schemas 
 
 - **list-contact-fields**: List all contact field definitions for the account.
 - **get-contact-field**: Get a contact field definition by ID.
+- **create-contact-field**: Create a new contact field. Requires `name`, unique `merge_tag`, and `data_type` (text/number/boolean/date).
 
 Tools use input schemas (JSON Schema format) for MCP; handlers may validate input with Zod. Response format follows the MCP protocol.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,5 +152,6 @@ Schema files define a JSON Schema–shaped object for MCP; optional Zod schemas 
 - **list-contact-fields**: List all contact field definitions for the account.
 - **get-contact-field**: Get a contact field definition by ID.
 - **create-contact-field**: Create a new contact field. Requires `name`, unique `merge_tag`, and `data_type` (text/number/boolean/date).
+- **update-contact-field**: Update name, merge_tag, or data_type of an existing contact field.
 
 Tools use input schemas (JSON Schema format) for MCP; handlers may validate input with Zod. Response format follows the MCP protocol.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,4 +146,9 @@ Schema files define a JSON Schema–shaped object for MCP; optional Zod schemas 
 - **update-contact-list**: Rename an existing contact list.
 - **delete-contact-list**: Permanently delete a contact list by ID.
 
+
+#### Contact Fields
+
+- **list-contact-fields**: List all contact field definitions for the account.
+
 Tools use input schemas (JSON Schema format) for MCP; handlers may validate input with Zod. Response format follows the MCP protocol.

--- a/README.md
+++ b/README.md
@@ -769,6 +769,17 @@ Create a new contact field definition. `merge_tag` must be unique within the acc
 - `merge_tag` (required): Unique placeholder name (e.g. `first_name`)
 - `data_type` (required): One of `text`, `number`, `boolean`, `date`
 
+### update-contact-field
+
+Update a contact field definition. Any combination of `name`, `merge_tag`, and `data_type` can be changed.
+
+**Parameters:**
+
+- `field_id` (required): ID of the contact field
+- `name` (optional): New display name
+- `merge_tag` (optional): New merge tag (must remain unique)
+- `data_type` (optional): One of `text`, `number`, `boolean`, `date`
+
 ## Development
 
 1. Clone the repository:

--- a/README.md
+++ b/README.md
@@ -751,6 +751,14 @@ List all contact field definitions for the account.
 
 - No parameters required
 
+### get-contact-field
+
+Get a contact field definition by ID.
+
+**Parameters:**
+
+- `field_id` (required): ID of the contact field
+
 ## Development
 
 1. Clone the repository:

--- a/README.md
+++ b/README.md
@@ -759,6 +759,16 @@ Get a contact field definition by ID.
 
 - `field_id` (required): ID of the contact field
 
+### create-contact-field
+
+Create a new contact field definition. `merge_tag` must be unique within the account and is used as the placeholder name in template variables.
+
+**Parameters:**
+
+- `name` (required): Display name (e.g. "First Name")
+- `merge_tag` (required): Unique placeholder name (e.g. `first_name`)
+- `data_type` (required): One of `text`, `number`, `boolean`, `date`
+
 ## Development
 
 1. Clone the repository:

--- a/README.md
+++ b/README.md
@@ -780,6 +780,14 @@ Update a contact field definition. Any combination of `name`, `merge_tag`, and `
 - `merge_tag` (optional): New merge tag (must remain unique)
 - `data_type` (optional): One of `text`, `number`, `boolean`, `date`
 
+### delete-contact-field
+
+Permanently delete a contact field definition by ID.
+
+**Parameters:**
+
+- `field_id` (required): ID of the contact field to delete
+
 ## Development
 
 1. Clone the repository:

--- a/README.md
+++ b/README.md
@@ -743,6 +743,14 @@ Permanently delete a contact list by ID.
 
 - `list_id` (required): ID of the contact list to delete
 
+### list-contact-fields
+
+List all contact field definitions for the account.
+
+**Parameters:**
+
+- No parameters required
+
 ## Development
 
 1. Clone the repository:

--- a/src/server.ts
+++ b/src/server.ts
@@ -149,6 +149,8 @@ import {
   createContactFieldSchema,
   updateContactField,
   updateContactFieldSchema,
+  deleteContactField,
+  deleteContactFieldSchema,
 } from "./tools/contactFields";
 
 // Define the tools registry
@@ -774,6 +776,15 @@ const tools = [
       "Update a contact field definition. Any combination of `name`, `merge_tag`, or `data_type` can be changed.",
     inputSchema: updateContactFieldSchema,
     handler: updateContactField,
+    annotations: {
+      destructiveHint: true,
+    },
+  },
+  {
+    name: "delete-contact-field",
+    description: "Permanently delete a contact field definition by ID.",
+    inputSchema: deleteContactFieldSchema,
+    handler: deleteContactField,
     annotations: {
       destructiveHint: true,
     },

--- a/src/server.ts
+++ b/src/server.ts
@@ -147,6 +147,8 @@ import {
   getContactFieldSchema,
   createContactField,
   createContactFieldSchema,
+  updateContactField,
+  updateContactFieldSchema,
 } from "./tools/contactFields";
 
 // Define the tools registry
@@ -762,6 +764,16 @@ const tools = [
       "Create a new contact field definition. `merge_tag` must be unique and is used in template variables.",
     inputSchema: createContactFieldSchema,
     handler: createContactField,
+    annotations: {
+      destructiveHint: true,
+    },
+  },
+  {
+    name: "update-contact-field",
+    description:
+      "Update a contact field definition. Any combination of `name`, `merge_tag`, or `data_type` can be changed.",
+    inputSchema: updateContactFieldSchema,
+    handler: updateContactField,
     annotations: {
       destructiveHint: true,
     },

--- a/src/server.ts
+++ b/src/server.ts
@@ -140,6 +140,10 @@ import {
   deleteContactList,
   deleteContactListSchema,
 } from "./tools/contactLists";
+import {
+  listContactFields,
+  listContactFieldsSchema,
+} from "./tools/contactFields";
 
 // Define the tools registry
 const tools = [
@@ -728,6 +732,15 @@ const tools = [
     handler: deleteContactList,
     annotations: {
       destructiveHint: true,
+    },
+  },
+  {
+    name: "list-contact-fields",
+    description: "List all contact field definitions for the account.",
+    inputSchema: listContactFieldsSchema,
+    handler: listContactFields,
+    annotations: {
+      readOnlyHint: true,
     },
   },
 ];

--- a/src/server.ts
+++ b/src/server.ts
@@ -143,6 +143,8 @@ import {
 import {
   listContactFields,
   listContactFieldsSchema,
+  getContactField,
+  getContactFieldSchema,
 } from "./tools/contactFields";
 
 // Define the tools registry
@@ -739,6 +741,15 @@ const tools = [
     description: "List all contact field definitions for the account.",
     inputSchema: listContactFieldsSchema,
     handler: listContactFields,
+    annotations: {
+      readOnlyHint: true,
+    },
+  },
+  {
+    name: "get-contact-field",
+    description: "Get a contact field definition by ID.",
+    inputSchema: getContactFieldSchema,
+    handler: getContactField,
     annotations: {
       readOnlyHint: true,
     },

--- a/src/server.ts
+++ b/src/server.ts
@@ -145,6 +145,8 @@ import {
   listContactFieldsSchema,
   getContactField,
   getContactFieldSchema,
+  createContactField,
+  createContactFieldSchema,
 } from "./tools/contactFields";
 
 // Define the tools registry
@@ -752,6 +754,16 @@ const tools = [
     handler: getContactField,
     annotations: {
       readOnlyHint: true,
+    },
+  },
+  {
+    name: "create-contact-field",
+    description:
+      "Create a new contact field definition. `merge_tag` must be unique and is used in template variables.",
+    inputSchema: createContactFieldSchema,
+    handler: createContactField,
+    annotations: {
+      destructiveHint: true,
     },
   },
 ];

--- a/src/tools/contactFields/__tests__/createContactField.test.ts
+++ b/src/tools/contactFields/__tests__/createContactField.test.ts
@@ -1,0 +1,65 @@
+import createContactField from "../createContactField";
+import { requireClient } from "../../../client";
+
+const mockClient = {
+  contactFields: {
+    create: jest.fn(),
+  },
+};
+
+jest.mock("../../../client", () => ({
+  requireClient: jest.fn(() => mockClient),
+}));
+
+describe("createContactField", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  it("creates a field and returns the result as JSON", async () => {
+    mockClient.contactFields.create.mockResolvedValue({
+      data: {
+        id: 42,
+        name: "First Name",
+        merge_tag: "first_name",
+        data_type: "text",
+        created_at: 1716100000,
+        updated_at: 1716100000,
+      },
+    });
+
+    const result = await createContactField({
+      name: "First Name",
+      merge_tag: "first_name",
+      data_type: "text",
+    });
+
+    expect(requireClient).toHaveBeenCalledWith("contact fields");
+    expect(mockClient.contactFields.create).toHaveBeenCalledWith({
+      name: "First Name",
+      merge_tag: "first_name",
+      data_type: "text",
+    });
+    expect(result.content[0].text).toContain('"id": 42');
+    expect(result.content[0].text).toContain('"merge_tag": "first_name"');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("surfaces API errors", async () => {
+    mockClient.contactFields.create.mockRejectedValue(
+      new Error("merge_tag is already in use")
+    );
+
+    const result = await createContactField({
+      name: "Duplicate",
+      merge_tag: "first_name",
+      data_type: "text",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to create contact field: merge_tag is already in use"
+    );
+  });
+});

--- a/src/tools/contactFields/__tests__/createContactField.test.ts
+++ b/src/tools/contactFields/__tests__/createContactField.test.ts
@@ -46,6 +46,27 @@ describe("createContactField", () => {
     expect(result.isError).toBeUndefined();
   });
 
+  it("handles a raw field response (no `data` wrapper)", async () => {
+    mockClient.contactFields.create.mockResolvedValue({
+      id: 42,
+      name: "First Name",
+      merge_tag: "first_name",
+      data_type: "text",
+      created_at: 1716100000,
+      updated_at: 1716100000,
+    });
+
+    const result = await createContactField({
+      name: "First Name",
+      merge_tag: "first_name",
+      data_type: "text",
+    });
+
+    expect(result.content[0].text).toContain('"id": 42');
+    expect(result.content[0].text).toContain('"merge_tag": "first_name"');
+    expect(result.isError).toBeUndefined();
+  });
+
   it("surfaces API errors", async () => {
     mockClient.contactFields.create.mockRejectedValue(
       new Error("merge_tag is already in use")

--- a/src/tools/contactFields/__tests__/createContactField.test.ts
+++ b/src/tools/contactFields/__tests__/createContactField.test.ts
@@ -67,6 +67,21 @@ describe("createContactField", () => {
     expect(result.isError).toBeUndefined();
   });
 
+  it("returns an error when the API responds with an empty payload", async () => {
+    mockClient.contactFields.create.mockResolvedValue(null);
+
+    const result = await createContactField({
+      name: "First Name",
+      merge_tag: "first_name",
+      data_type: "text",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to create contact field: empty response from contact fields API"
+    );
+  });
+
   it("surfaces API errors", async () => {
     mockClient.contactFields.create.mockRejectedValue(
       new Error("merge_tag is already in use")

--- a/src/tools/contactFields/__tests__/deleteContactField.test.ts
+++ b/src/tools/contactFields/__tests__/deleteContactField.test.ts
@@ -1,0 +1,42 @@
+import deleteContactField from "../deleteContactField";
+import { requireClient } from "../../../client";
+
+const mockClient = {
+  contactFields: {
+    delete: jest.fn(),
+  },
+};
+
+jest.mock("../../../client", () => ({
+  requireClient: jest.fn(() => mockClient),
+}));
+
+describe("deleteContactField", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  it("deletes the field and returns a confirmation payload", async () => {
+    mockClient.contactFields.delete.mockResolvedValue(undefined);
+
+    const result = await deleteContactField({ field_id: 7 });
+
+    expect(requireClient).toHaveBeenCalledWith("contact fields");
+    expect(mockClient.contactFields.delete).toHaveBeenCalledWith(7);
+    expect(result.content[0].text).toContain('"field_id": 7');
+    expect(result.content[0].text).toContain('"deleted": true');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("surfaces API errors", async () => {
+    mockClient.contactFields.delete.mockRejectedValue(new Error("not found"));
+
+    const result = await deleteContactField({ field_id: 99 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to delete contact field: not found"
+    );
+  });
+});

--- a/src/tools/contactFields/__tests__/getContactField.test.ts
+++ b/src/tools/contactFields/__tests__/getContactField.test.ts
@@ -38,6 +38,23 @@ describe("getContactField", () => {
     expect(result.isError).toBeUndefined();
   });
 
+  it("handles a raw field response (no `data` wrapper)", async () => {
+    mockClient.contactFields.get.mockResolvedValue({
+      id: 7,
+      name: "First Name",
+      merge_tag: "first_name",
+      data_type: "text",
+      created_at: 1716100000,
+      updated_at: 1716100000,
+    });
+
+    const result = await getContactField({ field_id: 7 });
+
+    expect(result.content[0].text).toContain('"id": 7');
+    expect(result.content[0].text).toContain('"merge_tag": "first_name"');
+    expect(result.isError).toBeUndefined();
+  });
+
   it("surfaces API errors", async () => {
     mockClient.contactFields.get.mockRejectedValue(new Error("not found"));
 

--- a/src/tools/contactFields/__tests__/getContactField.test.ts
+++ b/src/tools/contactFields/__tests__/getContactField.test.ts
@@ -55,6 +55,17 @@ describe("getContactField", () => {
     expect(result.isError).toBeUndefined();
   });
 
+  it("returns an error when the API responds with an empty payload", async () => {
+    mockClient.contactFields.get.mockResolvedValue(null);
+
+    const result = await getContactField({ field_id: 7 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to get contact field: empty response from contact fields API"
+    );
+  });
+
   it("surfaces API errors", async () => {
     mockClient.contactFields.get.mockRejectedValue(new Error("not found"));
 

--- a/src/tools/contactFields/__tests__/getContactField.test.ts
+++ b/src/tools/contactFields/__tests__/getContactField.test.ts
@@ -1,0 +1,51 @@
+import getContactField from "../getContactField";
+import { requireClient } from "../../../client";
+
+const mockClient = {
+  contactFields: {
+    get: jest.fn(),
+  },
+};
+
+jest.mock("../../../client", () => ({
+  requireClient: jest.fn(() => mockClient),
+}));
+
+describe("getContactField", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  it("returns the field as JSON", async () => {
+    mockClient.contactFields.get.mockResolvedValue({
+      data: {
+        id: 7,
+        name: "First Name",
+        merge_tag: "first_name",
+        data_type: "text",
+        created_at: 1716100000,
+        updated_at: 1716100000,
+      },
+    });
+
+    const result = await getContactField({ field_id: 7 });
+
+    expect(requireClient).toHaveBeenCalledWith("contact fields");
+    expect(mockClient.contactFields.get).toHaveBeenCalledWith(7);
+    expect(result.content[0].text).toContain('"id": 7');
+    expect(result.content[0].text).toContain('"merge_tag": "first_name"');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("surfaces API errors", async () => {
+    mockClient.contactFields.get.mockRejectedValue(new Error("not found"));
+
+    const result = await getContactField({ field_id: 99 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to get contact field: not found"
+    );
+  });
+});

--- a/src/tools/contactFields/__tests__/listContactFields.test.ts
+++ b/src/tools/contactFields/__tests__/listContactFields.test.ts
@@ -1,0 +1,80 @@
+import listContactFields from "../listContactFields";
+import { requireClient } from "../../../client";
+
+const mockClient = {
+  contactFields: {
+    getList: jest.fn(),
+  },
+};
+
+jest.mock("../../../client", () => ({
+  requireClient: jest.fn(() => mockClient),
+}));
+
+describe("listContactFields", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  it("returns the fields as JSON", async () => {
+    mockClient.contactFields.getList.mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          name: "First Name",
+          merge_tag: "first_name",
+          data_type: "text",
+          created_at: 1716100000,
+          updated_at: 1716100000,
+        },
+        {
+          id: 2,
+          name: "Age",
+          merge_tag: "age",
+          data_type: "number",
+          created_at: 1716100000,
+          updated_at: 1716100000,
+        },
+      ],
+    });
+
+    const result = await listContactFields();
+
+    expect(requireClient).toHaveBeenCalledWith("contact fields");
+    expect(mockClient.contactFields.getList).toHaveBeenCalledWith();
+    expect(result.content[0].text).toContain('"id": 1');
+    expect(result.content[0].text).toContain('"merge_tag": "first_name"');
+    expect(result.content[0].text).toContain('"data_type": "number"');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("returns the empty message when no fields exist", async () => {
+    mockClient.contactFields.getList.mockResolvedValue({ data: [] });
+
+    const result = await listContactFields();
+
+    expect(result.content[0].text).toBe(
+      "No contact fields in your Mailtrap account."
+    );
+  });
+
+  it("handles a response without data", async () => {
+    mockClient.contactFields.getList.mockResolvedValue(undefined);
+
+    const result = await listContactFields();
+
+    expect(result.content[0].text).toBe(
+      "No contact fields in your Mailtrap account."
+    );
+  });
+
+  it("surfaces API errors", async () => {
+    mockClient.contactFields.getList.mockRejectedValue(new Error("boom"));
+
+    const result = await listContactFields();
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe("Failed to list contact fields: boom");
+  });
+});

--- a/src/tools/contactFields/__tests__/listContactFields.test.ts
+++ b/src/tools/contactFields/__tests__/listContactFields.test.ts
@@ -69,6 +69,35 @@ describe("listContactFields", () => {
     );
   });
 
+  it("handles a raw array response (no `data` wrapper)", async () => {
+    mockClient.contactFields.getList.mockResolvedValue([
+      {
+        id: 7,
+        name: "Birthday",
+        merge_tag: "birthday",
+        data_type: "date",
+        created_at: 1716100000,
+        updated_at: 1716100000,
+      },
+    ]);
+
+    const result = await listContactFields();
+
+    expect(result.content[0].text).toContain('"id": 7');
+    expect(result.content[0].text).toContain('"data_type": "date"');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("returns the empty message for an empty raw-array response", async () => {
+    mockClient.contactFields.getList.mockResolvedValue([]);
+
+    const result = await listContactFields();
+
+    expect(result.content[0].text).toBe(
+      "No contact fields in your Mailtrap account."
+    );
+  });
+
   it("surfaces API errors", async () => {
     mockClient.contactFields.getList.mockRejectedValue(new Error("boom"));
 

--- a/src/tools/contactFields/__tests__/updateContactField.test.ts
+++ b/src/tools/contactFields/__tests__/updateContactField.test.ts
@@ -1,0 +1,71 @@
+import updateContactField from "../updateContactField";
+import { requireClient } from "../../../client";
+
+const mockClient = {
+  contactFields: {
+    update: jest.fn(),
+  },
+};
+
+jest.mock("../../../client", () => ({
+  requireClient: jest.fn(() => mockClient),
+}));
+
+describe("updateContactField", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  it("renames the field and returns the JSON response", async () => {
+    mockClient.contactFields.update.mockResolvedValue({
+      data: {
+        id: 7,
+        name: "Given Name",
+        merge_tag: "given_name",
+        data_type: "text",
+        created_at: 1716100000,
+        updated_at: 1716200000,
+      },
+    });
+
+    const result = await updateContactField({
+      field_id: 7,
+      name: "Given Name",
+      merge_tag: "given_name",
+    });
+
+    expect(requireClient).toHaveBeenCalledWith("contact fields");
+    expect(mockClient.contactFields.update).toHaveBeenCalledWith(7, {
+      name: "Given Name",
+      merge_tag: "given_name",
+    });
+    expect(result.content[0].text).toContain('"name": "Given Name"');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("passes only the fields the caller actually provided", async () => {
+    mockClient.contactFields.update.mockResolvedValue({
+      data: { id: 7, name: "Original" },
+    });
+
+    await updateContactField({ field_id: 7, data_type: "number" });
+
+    expect(mockClient.contactFields.update).toHaveBeenCalledWith(7, {
+      data_type: "number",
+    });
+  });
+
+  it("surfaces API errors", async () => {
+    mockClient.contactFields.update.mockRejectedValue(
+      new Error("validation failed")
+    );
+
+    const result = await updateContactField({ field_id: 7, name: "x" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to update contact field: validation failed"
+    );
+  });
+});

--- a/src/tools/contactFields/__tests__/updateContactField.test.ts
+++ b/src/tools/contactFields/__tests__/updateContactField.test.ts
@@ -56,6 +56,26 @@ describe("updateContactField", () => {
     });
   });
 
+  it("handles a raw field response (no `data` wrapper)", async () => {
+    mockClient.contactFields.update.mockResolvedValue({
+      id: 7,
+      name: "Given Name",
+      merge_tag: "given_name",
+      data_type: "text",
+      created_at: 1716100000,
+      updated_at: 1716200000,
+    });
+
+    const result = await updateContactField({
+      field_id: 7,
+      name: "Given Name",
+    });
+
+    expect(result.content[0].text).toContain('"id": 7');
+    expect(result.content[0].text).toContain('"name": "Given Name"');
+    expect(result.isError).toBeUndefined();
+  });
+
   it("surfaces API errors", async () => {
     mockClient.contactFields.update.mockRejectedValue(
       new Error("validation failed")

--- a/src/tools/contactFields/__tests__/updateContactField.test.ts
+++ b/src/tools/contactFields/__tests__/updateContactField.test.ts
@@ -76,6 +76,17 @@ describe("updateContactField", () => {
     expect(result.isError).toBeUndefined();
   });
 
+  it("returns an error when the API responds with an empty payload", async () => {
+    mockClient.contactFields.update.mockResolvedValue(null);
+
+    const result = await updateContactField({ field_id: 7, name: "x" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to update contact field: empty response from contact fields API"
+    );
+  });
+
   it("surfaces API errors", async () => {
     mockClient.contactFields.update.mockRejectedValue(
       new Error("validation failed")

--- a/src/tools/contactFields/createContactField.ts
+++ b/src/tools/contactFields/createContactField.ts
@@ -1,0 +1,25 @@
+import { requireClient } from "../../client";
+import { ContactField, CreateContactFieldRequest } from "../../types/mailtrap";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
+
+async function createContactField(
+  params: CreateContactFieldRequest
+): Promise<ToolResponse> {
+  try {
+    const mailtrap = requireClient("contact fields");
+
+    const response = (await mailtrap.contactFields.create(params)) as {
+      data: ContactField;
+    };
+
+    return buildSuccessResponse(JSON.stringify(response.data, null, 2));
+  } catch (error) {
+    return buildErrorResponse("create contact field", error);
+  }
+}
+
+export default createContactField;

--- a/src/tools/contactFields/createContactField.ts
+++ b/src/tools/contactFields/createContactField.ts
@@ -12,11 +12,17 @@ async function createContactField(
   try {
     const mailtrap = requireClient("contact fields");
 
-    const response = (await mailtrap.contactFields.create(params)) as {
-      data: ContactField;
-    };
+    const raw = (await mailtrap.contactFields.create(params)) as
+      | ContactField
+      | { data?: ContactField }
+      | null
+      | undefined;
+    const field =
+      raw && typeof raw === "object" && "data" in raw && raw.data
+        ? raw.data
+        : (raw as ContactField);
 
-    return buildSuccessResponse(JSON.stringify(response.data, null, 2));
+    return buildSuccessResponse(JSON.stringify(field, null, 2));
   } catch (error) {
     return buildErrorResponse("create contact field", error);
   }

--- a/src/tools/contactFields/createContactField.ts
+++ b/src/tools/contactFields/createContactField.ts
@@ -22,6 +22,13 @@ async function createContactField(
         ? raw.data
         : (raw as ContactField);
 
+    if (!field) {
+      return buildErrorResponse(
+        "create contact field",
+        new Error("empty response from contact fields API")
+      );
+    }
+
     return buildSuccessResponse(JSON.stringify(field, null, 2));
   } catch (error) {
     return buildErrorResponse("create contact field", error);

--- a/src/tools/contactFields/deleteContactField.ts
+++ b/src/tools/contactFields/deleteContactField.ts
@@ -1,0 +1,25 @@
+import { requireClient } from "../../client";
+import { DeleteContactFieldRequest } from "../../types/mailtrap";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
+
+async function deleteContactField({
+  field_id,
+}: DeleteContactFieldRequest): Promise<ToolResponse> {
+  try {
+    const mailtrap = requireClient("contact fields");
+
+    await mailtrap.contactFields.delete(field_id);
+
+    return buildSuccessResponse(
+      JSON.stringify({ field_id, deleted: true }, null, 2)
+    );
+  } catch (error) {
+    return buildErrorResponse("delete contact field", error);
+  }
+}
+
+export default deleteContactField;

--- a/src/tools/contactFields/getContactField.ts
+++ b/src/tools/contactFields/getContactField.ts
@@ -12,11 +12,17 @@ async function getContactField({
   try {
     const mailtrap = requireClient("contact fields");
 
-    const response = (await mailtrap.contactFields.get(field_id)) as {
-      data: ContactField;
-    };
+    const raw = (await mailtrap.contactFields.get(field_id)) as
+      | ContactField
+      | { data?: ContactField }
+      | null
+      | undefined;
+    const field =
+      raw && typeof raw === "object" && "data" in raw && raw.data
+        ? raw.data
+        : (raw as ContactField);
 
-    return buildSuccessResponse(JSON.stringify(response.data, null, 2));
+    return buildSuccessResponse(JSON.stringify(field, null, 2));
   } catch (error) {
     return buildErrorResponse("get contact field", error);
   }

--- a/src/tools/contactFields/getContactField.ts
+++ b/src/tools/contactFields/getContactField.ts
@@ -22,6 +22,13 @@ async function getContactField({
         ? raw.data
         : (raw as ContactField);
 
+    if (!field) {
+      return buildErrorResponse(
+        "get contact field",
+        new Error("empty response from contact fields API")
+      );
+    }
+
     return buildSuccessResponse(JSON.stringify(field, null, 2));
   } catch (error) {
     return buildErrorResponse("get contact field", error);

--- a/src/tools/contactFields/getContactField.ts
+++ b/src/tools/contactFields/getContactField.ts
@@ -1,0 +1,25 @@
+import { requireClient } from "../../client";
+import { ContactField, GetContactFieldRequest } from "../../types/mailtrap";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
+
+async function getContactField({
+  field_id,
+}: GetContactFieldRequest): Promise<ToolResponse> {
+  try {
+    const mailtrap = requireClient("contact fields");
+
+    const response = (await mailtrap.contactFields.get(field_id)) as {
+      data: ContactField;
+    };
+
+    return buildSuccessResponse(JSON.stringify(response.data, null, 2));
+  } catch (error) {
+    return buildErrorResponse("get contact field", error);
+  }
+}
+
+export default getContactField;

--- a/src/tools/contactFields/index.ts
+++ b/src/tools/contactFields/index.ts
@@ -1,4 +1,11 @@
 import listContactFieldsSchema from "./schemas/listContactFields";
 import listContactFields from "./listContactFields";
+import getContactFieldSchema from "./schemas/getContactField";
+import getContactField from "./getContactField";
 
-export { listContactFieldsSchema, listContactFields };
+export {
+  listContactFieldsSchema,
+  listContactFields,
+  getContactFieldSchema,
+  getContactField,
+};

--- a/src/tools/contactFields/index.ts
+++ b/src/tools/contactFields/index.ts
@@ -2,10 +2,14 @@ import listContactFieldsSchema from "./schemas/listContactFields";
 import listContactFields from "./listContactFields";
 import getContactFieldSchema from "./schemas/getContactField";
 import getContactField from "./getContactField";
+import createContactFieldSchema from "./schemas/createContactField";
+import createContactField from "./createContactField";
 
 export {
   listContactFieldsSchema,
   listContactFields,
   getContactFieldSchema,
   getContactField,
+  createContactFieldSchema,
+  createContactField,
 };

--- a/src/tools/contactFields/index.ts
+++ b/src/tools/contactFields/index.ts
@@ -4,6 +4,8 @@ import getContactFieldSchema from "./schemas/getContactField";
 import getContactField from "./getContactField";
 import createContactFieldSchema from "./schemas/createContactField";
 import createContactField from "./createContactField";
+import updateContactFieldSchema from "./schemas/updateContactField";
+import updateContactField from "./updateContactField";
 
 export {
   listContactFieldsSchema,
@@ -12,4 +14,6 @@ export {
   getContactField,
   createContactFieldSchema,
   createContactField,
+  updateContactFieldSchema,
+  updateContactField,
 };

--- a/src/tools/contactFields/index.ts
+++ b/src/tools/contactFields/index.ts
@@ -6,6 +6,8 @@ import createContactFieldSchema from "./schemas/createContactField";
 import createContactField from "./createContactField";
 import updateContactFieldSchema from "./schemas/updateContactField";
 import updateContactField from "./updateContactField";
+import deleteContactFieldSchema from "./schemas/deleteContactField";
+import deleteContactField from "./deleteContactField";
 
 export {
   listContactFieldsSchema,
@@ -16,4 +18,6 @@ export {
   createContactField,
   updateContactFieldSchema,
   updateContactField,
+  deleteContactFieldSchema,
+  deleteContactField,
 };

--- a/src/tools/contactFields/index.ts
+++ b/src/tools/contactFields/index.ts
@@ -1,0 +1,4 @@
+import listContactFieldsSchema from "./schemas/listContactFields";
+import listContactFields from "./listContactFields";
+
+export { listContactFieldsSchema, listContactFields };

--- a/src/tools/contactFields/listContactFields.ts
+++ b/src/tools/contactFields/listContactFields.ts
@@ -10,10 +10,12 @@ async function listContactFields(): Promise<ToolResponse> {
   try {
     const mailtrap = requireClient("contact fields");
 
-    const response = (await mailtrap.contactFields.getList()) as {
-      data: ContactField[];
-    };
-    const fields = response?.data ?? [];
+    const raw = (await mailtrap.contactFields.getList()) as
+      | ContactField[]
+      | { data?: ContactField[] }
+      | null
+      | undefined;
+    const fields: ContactField[] = Array.isArray(raw) ? raw : raw?.data ?? [];
 
     if (fields.length === 0) {
       return buildSuccessResponse(

--- a/src/tools/contactFields/listContactFields.ts
+++ b/src/tools/contactFields/listContactFields.ts
@@ -1,0 +1,30 @@
+import { requireClient } from "../../client";
+import { ContactField } from "../../types/mailtrap";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
+
+async function listContactFields(): Promise<ToolResponse> {
+  try {
+    const mailtrap = requireClient("contact fields");
+
+    const response = (await mailtrap.contactFields.getList()) as {
+      data: ContactField[];
+    };
+    const fields = response?.data ?? [];
+
+    if (fields.length === 0) {
+      return buildSuccessResponse(
+        "No contact fields in your Mailtrap account."
+      );
+    }
+
+    return buildSuccessResponse(JSON.stringify(fields, null, 2));
+  } catch (error) {
+    return buildErrorResponse("list contact fields", error);
+  }
+}
+
+export default listContactFields;

--- a/src/tools/contactFields/schemas/createContactField.ts
+++ b/src/tools/contactFields/schemas/createContactField.ts
@@ -1,0 +1,23 @@
+const createContactFieldSchema = {
+  type: "object",
+  properties: {
+    name: {
+      type: "string",
+      description: 'Display name of the field (e.g. "First Name").',
+    },
+    merge_tag: {
+      type: "string",
+      description:
+        "Merge tag used in template variables (e.g. `first_name`). Must be unique.",
+    },
+    data_type: {
+      type: "string",
+      enum: ["text", "number", "boolean", "date"],
+      description: "Data type stored in this field.",
+    },
+  },
+  required: ["name", "merge_tag", "data_type"],
+  additionalProperties: false,
+};
+
+export default createContactFieldSchema;

--- a/src/tools/contactFields/schemas/deleteContactField.ts
+++ b/src/tools/contactFields/schemas/deleteContactField.ts
@@ -1,0 +1,13 @@
+const deleteContactFieldSchema = {
+  type: "object",
+  properties: {
+    field_id: {
+      type: "number",
+      description: "ID of the contact field to delete.",
+    },
+  },
+  required: ["field_id"],
+  additionalProperties: false,
+};
+
+export default deleteContactFieldSchema;

--- a/src/tools/contactFields/schemas/getContactField.ts
+++ b/src/tools/contactFields/schemas/getContactField.ts
@@ -1,0 +1,13 @@
+const getContactFieldSchema = {
+  type: "object",
+  properties: {
+    field_id: {
+      type: "number",
+      description: "ID of the contact field to fetch.",
+    },
+  },
+  required: ["field_id"],
+  additionalProperties: false,
+};
+
+export default getContactFieldSchema;

--- a/src/tools/contactFields/schemas/listContactFields.ts
+++ b/src/tools/contactFields/schemas/listContactFields.ts
@@ -1,0 +1,7 @@
+const listContactFieldsSchema = {
+  type: "object",
+  properties: {},
+  additionalProperties: false,
+};
+
+export default listContactFieldsSchema;

--- a/src/tools/contactFields/schemas/updateContactField.ts
+++ b/src/tools/contactFields/schemas/updateContactField.ts
@@ -1,0 +1,26 @@
+const updateContactFieldSchema = {
+  type: "object",
+  properties: {
+    field_id: {
+      type: "number",
+      description: "ID of the contact field to update.",
+    },
+    name: {
+      type: "string",
+      description: "New display name for the field.",
+    },
+    merge_tag: {
+      type: "string",
+      description: "New merge tag for the field. Must be unique.",
+    },
+    data_type: {
+      type: "string",
+      enum: ["text", "number", "boolean", "date"],
+      description: "New data type for the field.",
+    },
+  },
+  required: ["field_id"],
+  additionalProperties: false,
+};
+
+export default updateContactFieldSchema;

--- a/src/tools/contactFields/updateContactField.ts
+++ b/src/tools/contactFields/updateContactField.ts
@@ -13,12 +13,17 @@ async function updateContactField({
   try {
     const mailtrap = requireClient("contact fields");
 
-    const response = (await mailtrap.contactFields.update(
-      field_id,
-      params
-    )) as { data: ContactField };
+    const raw = (await mailtrap.contactFields.update(field_id, params)) as
+      | ContactField
+      | { data?: ContactField }
+      | null
+      | undefined;
+    const field =
+      raw && typeof raw === "object" && "data" in raw && raw.data
+        ? raw.data
+        : (raw as ContactField);
 
-    return buildSuccessResponse(JSON.stringify(response.data, null, 2));
+    return buildSuccessResponse(JSON.stringify(field, null, 2));
   } catch (error) {
     return buildErrorResponse("update contact field", error);
   }

--- a/src/tools/contactFields/updateContactField.ts
+++ b/src/tools/contactFields/updateContactField.ts
@@ -23,6 +23,13 @@ async function updateContactField({
         ? raw.data
         : (raw as ContactField);
 
+    if (!field) {
+      return buildErrorResponse(
+        "update contact field",
+        new Error("empty response from contact fields API")
+      );
+    }
+
     return buildSuccessResponse(JSON.stringify(field, null, 2));
   } catch (error) {
     return buildErrorResponse("update contact field", error);

--- a/src/tools/contactFields/updateContactField.ts
+++ b/src/tools/contactFields/updateContactField.ts
@@ -1,0 +1,27 @@
+import { requireClient } from "../../client";
+import { ContactField, UpdateContactFieldRequest } from "../../types/mailtrap";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
+
+async function updateContactField({
+  field_id,
+  ...params
+}: UpdateContactFieldRequest): Promise<ToolResponse> {
+  try {
+    const mailtrap = requireClient("contact fields");
+
+    const response = (await mailtrap.contactFields.update(
+      field_id,
+      params
+    )) as { data: ContactField };
+
+    return buildSuccessResponse(JSON.stringify(response.data, null, 2));
+  } catch (error) {
+    return buildErrorResponse("update contact field", error);
+  }
+}
+
+export default updateContactField;

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -463,3 +463,37 @@ export interface UpdateContactListRequest {
   list_id: number;
   name: string;
 }
+
+// --- Contact field types ---
+
+export type ContactFieldDataType = "text" | "number" | "boolean" | "date";
+
+export interface ContactField {
+  id: number;
+  name: string;
+  merge_tag: string;
+  data_type: ContactFieldDataType;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface GetContactFieldRequest {
+  field_id: number;
+}
+
+export interface DeleteContactFieldRequest {
+  field_id: number;
+}
+
+export interface CreateContactFieldRequest {
+  name: string;
+  merge_tag: string;
+  data_type: ContactFieldDataType;
+}
+
+export interface UpdateContactFieldRequest {
+  field_id: number;
+  name?: string;
+  merge_tag?: string;
+  data_type?: ContactFieldDataType;
+}


### PR DESCRIPTION
## Motivation


## Changes

  - list-contact-fields — list all contact field definitions
  - get-contact-field — get a field by ID
  - create-contact-field — name + unique merge_tag + data_type (text/number/boolean/date)
  - update-contact-field — partial update of name / merge_tag / data_type
  - delete-contact-field — delete a field by ID



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added contact field management capabilities with five new operations: list all contact field definitions, fetch a specific field, create new contact fields, update existing fields, and delete contact fields.

* **Documentation**
  * Updated guides and documentation to reflect the new contact field management tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailtrap/mailtrap-mcp/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->