### PR TITLE
Add missing contact import export tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,5 +159,6 @@ Schema files define a JSON Schema–shaped object for MCP; optional Zod schemas 
 #### Contact Imports & Exports
 
 - **create-contact-import**: Bulk import contacts (array of `{ email, fields?, list_ids_included?, list_ids_excluded? }`). Returns an import job.
+- **get-contact-import**: Get the status of a contact import job (`created`/`started`/`finished`/`failed`) and counts.
 
 Tools use input schemas (JSON Schema format) for MCP; handlers may validate input with Zod. Response format follows the MCP protocol.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,5 +160,6 @@ Schema files define a JSON Schema–shaped object for MCP; optional Zod schemas 
 
 - **create-contact-import**: Bulk import contacts (array of `{ email, fields?, list_ids_included?, list_ids_excluded? }`). Returns an import job.
 - **get-contact-import**: Get the status of a contact import job (`created`/`started`/`finished`/`failed`) and counts.
+- **create-contact-export**: Export contacts matching AND-combined filters (`name`/`operator`/`value`). Returns an export job; poll for download URL.
 
 Tools use input schemas (JSON Schema format) for MCP; handlers may validate input with Zod. Response format follows the MCP protocol.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,4 +155,9 @@ Schema files define a JSON Schema–shaped object for MCP; optional Zod schemas 
 - **update-contact-field**: Update name, merge_tag, or data_type of an existing contact field.
 - **delete-contact-field**: Permanently delete a contact field by ID.
 
+
+#### Contact Imports & Exports
+
+- **create-contact-import**: Bulk import contacts (array of `{ email, fields?, list_ids_included?, list_ids_excluded? }`). Returns an import job.
+
 Tools use input schemas (JSON Schema format) for MCP; handlers may validate input with Zod. Response format follows the MCP protocol.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,5 +161,6 @@ Schema files define a JSON Schema–shaped object for MCP; optional Zod schemas 
 - **create-contact-import**: Bulk import contacts (array of `{ email, fields?, list_ids_included?, list_ids_excluded? }`). Returns an import job.
 - **get-contact-import**: Get the status of a contact import job (`created`/`started`/`finished`/`failed`) and counts.
 - **create-contact-export**: Export contacts matching AND-combined filters (`name`/`operator`/`value`). Returns an export job; poll for download URL.
+- **get-contact-export**: Get the status of a contact export job. `url` is populated when `status: finished`.
 
 Tools use input schemas (JSON Schema format) for MCP; handlers may validate input with Zod. Response format follows the MCP protocol.

--- a/README.md
+++ b/README.md
@@ -800,6 +800,14 @@ Bulk import contacts. Returns an import job record; poll its status with `get-co
   - `list_ids_included` (optional): List IDs to add the contact to
   - `list_ids_excluded` (optional): List IDs to remove the contact from
 
+### get-contact-import
+
+Get the status of a contact import job (created/started/finished/failed) with created/updated/over-limit counts.
+
+**Parameters:**
+
+- `import_id` (required): ID of the contact import job
+
 ## Development
 
 1. Clone the repository:

--- a/README.md
+++ b/README.md
@@ -819,6 +819,14 @@ Export contacts matching a set of AND-combined filters. Returns an export job re
   - `operator` (required): One of `equal`, `not_equal`, `contains`, `not_contains`, `is_empty`, `is_not_empty`
   - `value` (required): Comparison value (string, number, boolean, or array)
 
+### get-contact-export
+
+Get the status of a contact export job. Once `status` is `finished`, the `url` field holds the CSV download link.
+
+**Parameters:**
+
+- `export_id` (required): ID of the contact export job
+
 ## Development
 
 1. Clone the repository:

--- a/README.md
+++ b/README.md
@@ -808,6 +808,17 @@ Get the status of a contact import job (created/started/finished/failed) with cr
 
 - `import_id` (required): ID of the contact import job
 
+### create-contact-export
+
+Export contacts matching a set of AND-combined filters. Returns an export job record; poll status with `get-contact-export` to retrieve the download URL once `status` is `finished`.
+
+**Parameters:**
+
+- `filters` (required): Array of filter objects. Each has:
+  - `name` (required): Field to filter on (`list_id`, `subscription_status`, `email`, etc.)
+  - `operator` (required): One of `equal`, `not_equal`, `contains`, `not_contains`, `is_empty`, `is_not_empty`
+  - `value` (required): Comparison value (string, number, boolean, or array)
+
 ## Development
 
 1. Clone the repository:

--- a/README.md
+++ b/README.md
@@ -788,6 +788,18 @@ Permanently delete a contact field definition by ID.
 
 - `field_id` (required): ID of the contact field to delete
 
+### create-contact-import
+
+Bulk import contacts. Returns an import job record; poll its status with `get-contact-import`.
+
+**Parameters:**
+
+- `contacts` (required): Array of contact entries. Each entry needs:
+  - `email` (required): Contact email address
+  - `fields` (optional): Custom field values keyed by merge tag (string or number values)
+  - `list_ids_included` (optional): List IDs to add the contact to
+  - `list_ids_excluded` (optional): List IDs to remove the contact from
+
 ## Development
 
 1. Clone the repository:

--- a/src/server.ts
+++ b/src/server.ts
@@ -161,6 +161,8 @@ import {
 import {
   createContactExport,
   createContactExportSchema,
+  getContactExport,
+  getContactExportSchema,
 } from "./tools/contactExports";
 
 // Define the tools registry
@@ -827,6 +829,16 @@ const tools = [
     handler: createContactExport,
     annotations: {
       destructiveHint: false,
+    },
+  },
+  {
+    name: "get-contact-export",
+    description:
+      "Get the status of a contact export job. Once `status` is `finished`, the `url` field holds the download link.",
+    inputSchema: getContactExportSchema,
+    handler: getContactExport,
+    annotations: {
+      readOnlyHint: true,
     },
   },
 ];

--- a/src/server.ts
+++ b/src/server.ts
@@ -152,6 +152,10 @@ import {
   deleteContactField,
   deleteContactFieldSchema,
 } from "./tools/contactFields";
+import {
+  createContactImport,
+  createContactImportSchema,
+} from "./tools/contactImports";
 
 // Define the tools registry
 const tools = [
@@ -785,6 +789,16 @@ const tools = [
     description: "Permanently delete a contact field definition by ID.",
     inputSchema: deleteContactFieldSchema,
     handler: deleteContactField,
+    annotations: {
+      destructiveHint: true,
+    },
+  },
+  {
+    name: "create-contact-import",
+    description:
+      "Bulk import contacts. Returns an import job record; poll status via `get-contact-import`.",
+    inputSchema: createContactImportSchema,
+    handler: createContactImport,
     annotations: {
       destructiveHint: true,
     },

--- a/src/server.ts
+++ b/src/server.ts
@@ -158,6 +158,10 @@ import {
   getContactImport,
   getContactImportSchema,
 } from "./tools/contactImports";
+import {
+  createContactExport,
+  createContactExportSchema,
+} from "./tools/contactExports";
 
 // Define the tools registry
 const tools = [
@@ -813,6 +817,16 @@ const tools = [
     handler: getContactImport,
     annotations: {
       readOnlyHint: true,
+    },
+  },
+  {
+    name: "create-contact-export",
+    description:
+      "Export contacts matching a set of AND-combined filters. Returns an export job; poll status with `get-contact-export` to retrieve the download URL.",
+    inputSchema: createContactExportSchema,
+    handler: createContactExport,
+    annotations: {
+      destructiveHint: false,
     },
   },
 ];

--- a/src/server.ts
+++ b/src/server.ts
@@ -155,6 +155,8 @@ import {
 import {
   createContactImport,
   createContactImportSchema,
+  getContactImport,
+  getContactImportSchema,
 } from "./tools/contactImports";
 
 // Define the tools registry
@@ -801,6 +803,16 @@ const tools = [
     handler: createContactImport,
     annotations: {
       destructiveHint: true,
+    },
+  },
+  {
+    name: "get-contact-import",
+    description:
+      "Get the status of a contact import job, including created/updated/over-limit counts.",
+    inputSchema: getContactImportSchema,
+    handler: getContactImport,
+    annotations: {
+      readOnlyHint: true,
     },
   },
 ];

--- a/src/tools/contactExports/__tests__/createContactExport.test.ts
+++ b/src/tools/contactExports/__tests__/createContactExport.test.ts
@@ -39,6 +39,21 @@ describe("createContactExport", () => {
     expect(result.isError).toBeUndefined();
   });
 
+  it("submits filters without a value for is_empty / is_not_empty operators", async () => {
+    mockClient.contactExports.create.mockResolvedValue({
+      id: 43,
+      status: "started",
+    });
+
+    await createContactExport({
+      filters: [{ name: "email", operator: "is_empty" }],
+    });
+
+    expect(mockClient.contactExports.create).toHaveBeenCalledWith({
+      filters: [{ name: "email", operator: "is_empty" }],
+    });
+  });
+
   it("surfaces API errors", async () => {
     mockClient.contactExports.create.mockRejectedValue(
       new Error("invalid filter")

--- a/src/tools/contactExports/__tests__/createContactExport.test.ts
+++ b/src/tools/contactExports/__tests__/createContactExport.test.ts
@@ -1,0 +1,56 @@
+import createContactExport from "../createContactExport";
+import { requireClient } from "../../../client";
+
+const mockClient = {
+  contactExports: {
+    create: jest.fn(),
+  },
+};
+
+jest.mock("../../../client", () => ({
+  requireClient: jest.fn(() => mockClient),
+}));
+
+describe("createContactExport", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  it("submits the export and returns the response as JSON", async () => {
+    mockClient.contactExports.create.mockResolvedValue({
+      id: 42,
+      status: "started",
+      created_at: "2026-05-20T10:00:00Z",
+      updated_at: "2026-05-20T10:00:00Z",
+      url: null,
+    });
+
+    const result = await createContactExport({
+      filters: [{ name: "list_id", operator: "equal", value: 10 }],
+    });
+
+    expect(requireClient).toHaveBeenCalledWith("contact exports");
+    expect(mockClient.contactExports.create).toHaveBeenCalledWith({
+      filters: [{ name: "list_id", operator: "equal", value: 10 }],
+    });
+    expect(result.content[0].text).toContain('"id": 42');
+    expect(result.content[0].text).toContain('"status": "started"');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("surfaces API errors", async () => {
+    mockClient.contactExports.create.mockRejectedValue(
+      new Error("invalid filter")
+    );
+
+    const result = await createContactExport({
+      filters: [{ name: "bad", operator: "equal", value: "x" }],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to create contact export: invalid filter"
+    );
+  });
+});

--- a/src/tools/contactExports/__tests__/getContactExport.test.ts
+++ b/src/tools/contactExports/__tests__/getContactExport.test.ts
@@ -1,0 +1,65 @@
+import getContactExport from "../getContactExport";
+import { requireClient } from "../../../client";
+
+const mockClient = {
+  contactExports: {
+    get: jest.fn(),
+  },
+};
+
+jest.mock("../../../client", () => ({
+  requireClient: jest.fn(() => mockClient),
+}));
+
+describe("getContactExport", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  it("returns the export job as JSON", async () => {
+    mockClient.contactExports.get.mockResolvedValue({
+      id: 42,
+      status: "finished",
+      created_at: "2026-05-20T10:00:00Z",
+      updated_at: "2026-05-20T10:01:30Z",
+      url: "https://example.com/exports/42.csv",
+    });
+
+    const result = await getContactExport({ export_id: 42 });
+
+    expect(requireClient).toHaveBeenCalledWith("contact exports");
+    expect(mockClient.contactExports.get).toHaveBeenCalledWith(42);
+    expect(result.content[0].text).toContain('"id": 42');
+    expect(result.content[0].text).toContain('"status": "finished"');
+    expect(result.content[0].text).toContain(
+      '"url": "https://example.com/exports/42.csv"'
+    );
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("handles a started export with null url", async () => {
+    mockClient.contactExports.get.mockResolvedValue({
+      id: 42,
+      status: "started",
+      created_at: "2026-05-20T10:00:00Z",
+      updated_at: "2026-05-20T10:00:00Z",
+      url: null,
+    });
+
+    const result = await getContactExport({ export_id: 42 });
+
+    expect(result.content[0].text).toContain('"url": null');
+  });
+
+  it("surfaces API errors", async () => {
+    mockClient.contactExports.get.mockRejectedValue(new Error("not found"));
+
+    const result = await getContactExport({ export_id: 99 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to get contact export: not found"
+    );
+  });
+});

--- a/src/tools/contactExports/createContactExport.ts
+++ b/src/tools/contactExports/createContactExport.ts
@@ -1,0 +1,28 @@
+import { requireClient } from "../../client";
+import {
+  ContactExport,
+  CreateContactExportRequest,
+} from "../../types/mailtrap";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
+
+async function createContactExport(
+  params: CreateContactExportRequest
+): Promise<ToolResponse> {
+  try {
+    const mailtrap = requireClient("contact exports");
+
+    const response = (await mailtrap.contactExports.create(
+      params as Parameters<typeof mailtrap.contactExports.create>[0]
+    )) as ContactExport;
+
+    return buildSuccessResponse(JSON.stringify(response, null, 2));
+  } catch (error) {
+    return buildErrorResponse("create contact export", error);
+  }
+}
+
+export default createContactExport;

--- a/src/tools/contactExports/getContactExport.ts
+++ b/src/tools/contactExports/getContactExport.ts
@@ -1,0 +1,25 @@
+import { requireClient } from "../../client";
+import { ContactExport, GetContactExportRequest } from "../../types/mailtrap";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
+
+async function getContactExport({
+  export_id,
+}: GetContactExportRequest): Promise<ToolResponse> {
+  try {
+    const mailtrap = requireClient("contact exports");
+
+    const response = (await mailtrap.contactExports.get(
+      export_id
+    )) as ContactExport;
+
+    return buildSuccessResponse(JSON.stringify(response, null, 2));
+  } catch (error) {
+    return buildErrorResponse("get contact export", error);
+  }
+}
+
+export default getContactExport;

--- a/src/tools/contactExports/index.ts
+++ b/src/tools/contactExports/index.ts
@@ -1,4 +1,11 @@
 import createContactExportSchema from "./schemas/createContactExport";
 import createContactExport from "./createContactExport";
+import getContactExportSchema from "./schemas/getContactExport";
+import getContactExport from "./getContactExport";
 
-export { createContactExportSchema, createContactExport };
+export {
+  createContactExportSchema,
+  createContactExport,
+  getContactExportSchema,
+  getContactExport,
+};

--- a/src/tools/contactExports/index.ts
+++ b/src/tools/contactExports/index.ts
@@ -1,0 +1,4 @@
+import createContactExportSchema from "./schemas/createContactExport";
+import createContactExport from "./createContactExport";
+
+export { createContactExportSchema, createContactExport };

--- a/src/tools/contactExports/schemas/createContactExport.ts
+++ b/src/tools/contactExports/schemas/createContactExport.ts
@@ -30,7 +30,23 @@ const createContactExportSchema = {
               "Comparison value. Type depends on the field — string, number, boolean, or array.",
           },
         },
-        required: ["name", "operator", "value"],
+        required: ["name", "operator"],
+        allOf: [
+          {
+            if: {
+              properties: {
+                operator: { enum: ["is_empty", "is_not_empty"] },
+              },
+              required: ["operator"],
+            },
+            then: {
+              not: { required: ["value"] },
+            },
+            else: {
+              required: ["value"],
+            },
+          },
+        ],
         additionalProperties: false,
       },
     },

--- a/src/tools/contactExports/schemas/createContactExport.ts
+++ b/src/tools/contactExports/schemas/createContactExport.ts
@@ -1,0 +1,42 @@
+const createContactExportSchema = {
+  type: "object",
+  properties: {
+    filters: {
+      type: "array",
+      description:
+        "Filters that select which contacts to include in the export. AND-combined.",
+      items: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+            description:
+              "Field to filter on (e.g. `list_id`, `subscription_status`, `email`).",
+          },
+          operator: {
+            type: "string",
+            enum: [
+              "equal",
+              "not_equal",
+              "contains",
+              "not_contains",
+              "is_empty",
+              "is_not_empty",
+            ],
+            description: "Comparison operator.",
+          },
+          value: {
+            description:
+              "Comparison value. Type depends on the field — string, number, boolean, or array.",
+          },
+        },
+        required: ["name", "operator", "value"],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ["filters"],
+  additionalProperties: false,
+};
+
+export default createContactExportSchema;

--- a/src/tools/contactExports/schemas/getContactExport.ts
+++ b/src/tools/contactExports/schemas/getContactExport.ts
@@ -1,0 +1,13 @@
+const getContactExportSchema = {
+  type: "object",
+  properties: {
+    export_id: {
+      type: "number",
+      description: "ID of the contact export job to fetch.",
+    },
+  },
+  required: ["export_id"],
+  additionalProperties: false,
+};
+
+export default getContactExportSchema;

--- a/src/tools/contactImports/__tests__/createContactImport.test.ts
+++ b/src/tools/contactImports/__tests__/createContactImport.test.ts
@@ -1,0 +1,67 @@
+import createContactImport from "../createContactImport";
+import { requireClient } from "../../../client";
+
+const mockClient = {
+  contactImports: {
+    create: jest.fn(),
+  },
+};
+
+jest.mock("../../../client", () => ({
+  requireClient: jest.fn(() => mockClient),
+}));
+
+describe("createContactImport", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  it("submits the import and returns the response as JSON", async () => {
+    mockClient.contactImports.create.mockResolvedValue({
+      id: 42,
+      status: "created",
+    });
+
+    const result = await createContactImport({
+      contacts: [
+        {
+          email: "alice@example.com",
+          fields: { first_name: "Alice" },
+          list_ids_included: [10],
+        },
+        { email: "bob@example.com" },
+      ],
+    });
+
+    expect(requireClient).toHaveBeenCalledWith("contact imports");
+    expect(mockClient.contactImports.create).toHaveBeenCalledWith({
+      contacts: [
+        {
+          email: "alice@example.com",
+          fields: { first_name: "Alice" },
+          list_ids_included: [10],
+        },
+        { email: "bob@example.com" },
+      ],
+    });
+    expect(result.content[0].text).toContain('"id": 42');
+    expect(result.content[0].text).toContain('"status": "created"');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("surfaces API errors", async () => {
+    mockClient.contactImports.create.mockRejectedValue(
+      new Error("over plan limit")
+    );
+
+    const result = await createContactImport({
+      contacts: [{ email: "x@y.com" }],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to create contact import: over plan limit"
+    );
+  });
+});

--- a/src/tools/contactImports/__tests__/getContactImport.test.ts
+++ b/src/tools/contactImports/__tests__/getContactImport.test.ts
@@ -1,0 +1,49 @@
+import getContactImport from "../getContactImport";
+import { requireClient } from "../../../client";
+
+const mockClient = {
+  contactImports: {
+    get: jest.fn(),
+  },
+};
+
+jest.mock("../../../client", () => ({
+  requireClient: jest.fn(() => mockClient),
+}));
+
+describe("getContactImport", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  it("returns the import job as JSON", async () => {
+    mockClient.contactImports.get.mockResolvedValue({
+      id: 42,
+      status: "finished",
+      created_contacts_count: 100,
+      updated_contacts_count: 5,
+      contacts_over_limit_count: 0,
+    });
+
+    const result = await getContactImport({ import_id: 42 });
+
+    expect(requireClient).toHaveBeenCalledWith("contact imports");
+    expect(mockClient.contactImports.get).toHaveBeenCalledWith(42);
+    expect(result.content[0].text).toContain('"id": 42');
+    expect(result.content[0].text).toContain('"status": "finished"');
+    expect(result.content[0].text).toContain('"created_contacts_count": 100');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("surfaces API errors", async () => {
+    mockClient.contactImports.get.mockRejectedValue(new Error("not found"));
+
+    const result = await getContactImport({ import_id: 99 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to get contact import: not found"
+    );
+  });
+});

--- a/src/tools/contactImports/createContactImport.ts
+++ b/src/tools/contactImports/createContactImport.ts
@@ -1,0 +1,28 @@
+import { requireClient } from "../../client";
+import {
+  ContactImport,
+  CreateContactImportRequest,
+} from "../../types/mailtrap";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
+
+async function createContactImport(
+  params: CreateContactImportRequest
+): Promise<ToolResponse> {
+  try {
+    const mailtrap = requireClient("contact imports");
+
+    const response = (await mailtrap.contactImports.create(
+      params as Parameters<typeof mailtrap.contactImports.create>[0]
+    )) as ContactImport;
+
+    return buildSuccessResponse(JSON.stringify(response, null, 2));
+  } catch (error) {
+    return buildErrorResponse("create contact import", error);
+  }
+}
+
+export default createContactImport;

--- a/src/tools/contactImports/getContactImport.ts
+++ b/src/tools/contactImports/getContactImport.ts
@@ -1,0 +1,25 @@
+import { requireClient } from "../../client";
+import { ContactImport, GetContactImportRequest } from "../../types/mailtrap";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
+
+async function getContactImport({
+  import_id,
+}: GetContactImportRequest): Promise<ToolResponse> {
+  try {
+    const mailtrap = requireClient("contact imports");
+
+    const response = (await mailtrap.contactImports.get(
+      import_id
+    )) as ContactImport;
+
+    return buildSuccessResponse(JSON.stringify(response, null, 2));
+  } catch (error) {
+    return buildErrorResponse("get contact import", error);
+  }
+}
+
+export default getContactImport;

--- a/src/tools/contactImports/index.ts
+++ b/src/tools/contactImports/index.ts
@@ -1,0 +1,4 @@
+import createContactImportSchema from "./schemas/createContactImport";
+import createContactImport from "./createContactImport";
+
+export { createContactImportSchema, createContactImport };

--- a/src/tools/contactImports/index.ts
+++ b/src/tools/contactImports/index.ts
@@ -1,4 +1,11 @@
 import createContactImportSchema from "./schemas/createContactImport";
 import createContactImport from "./createContactImport";
+import getContactImportSchema from "./schemas/getContactImport";
+import getContactImport from "./getContactImport";
 
-export { createContactImportSchema, createContactImport };
+export {
+  createContactImportSchema,
+  createContactImport,
+  getContactImportSchema,
+  getContactImport,
+};

--- a/src/tools/contactImports/schemas/createContactImport.ts
+++ b/src/tools/contactImports/schemas/createContactImport.ts
@@ -1,0 +1,43 @@
+const createContactImportSchema = {
+  type: "object",
+  properties: {
+    contacts: {
+      type: "array",
+      description:
+        "Contacts to import. Each entry needs at least an `email`; optionally include custom `fields`, `list_ids_included`, and `list_ids_excluded`.",
+      items: {
+        type: "object",
+        properties: {
+          email: {
+            type: "string",
+            description: "Email address of the contact.",
+          },
+          fields: {
+            type: "object",
+            description:
+              "Custom field values keyed by merge tag. Values may be string or number.",
+            additionalProperties: {
+              type: ["string", "number"],
+            },
+          },
+          list_ids_included: {
+            type: "array",
+            items: { type: "number" },
+            description: "Contact list IDs to add this contact to.",
+          },
+          list_ids_excluded: {
+            type: "array",
+            items: { type: "number" },
+            description: "Contact list IDs to remove this contact from.",
+          },
+        },
+        required: ["email"],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ["contacts"],
+  additionalProperties: false,
+};
+
+export default createContactImportSchema;

--- a/src/tools/contactImports/schemas/getContactImport.ts
+++ b/src/tools/contactImports/schemas/getContactImport.ts
@@ -1,0 +1,13 @@
+const getContactImportSchema = {
+  type: "object",
+  properties: {
+    import_id: {
+      type: "number",
+      description: "ID of the contact import job to fetch.",
+    },
+  },
+  required: ["import_id"],
+  additionalProperties: false,
+};
+
+export default getContactImportSchema;

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -554,11 +554,16 @@ export type ContactExportFilterValue =
   | string[]
   | number[];
 
-export interface ContactExportFilter {
-  name: string;
-  operator: ContactExportFilterOperator;
-  value: ContactExportFilterValue;
-}
+export type ContactExportFilter =
+  | {
+      name: string;
+      operator: "is_empty" | "is_not_empty";
+    }
+  | {
+      name: string;
+      operator: "equal" | "not_equal" | "contains" | "not_contains";
+      value: ContactExportFilterValue;
+    };
 
 export interface CreateContactExportRequest {
   filters: ContactExportFilter[];

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -497,3 +497,73 @@ export interface UpdateContactFieldRequest {
   merge_tag?: string;
   data_type?: ContactFieldDataType;
 }
+
+// --- Contact import types ---
+
+export type ContactImportStatus = "created" | "started" | "finished" | "failed";
+
+export interface ContactImport {
+  id: number;
+  status: ContactImportStatus;
+  created_contacts_count?: number;
+  updated_contacts_count?: number;
+  contacts_over_limit_count?: number;
+}
+
+export type ContactImportFieldValue = string | number;
+
+export interface ContactImportItem {
+  email: string;
+  fields?: Record<string, ContactImportFieldValue>;
+  list_ids_included?: number[];
+  list_ids_excluded?: number[];
+}
+
+export interface CreateContactImportRequest {
+  contacts: ContactImportItem[];
+}
+
+export interface GetContactImportRequest {
+  import_id: number;
+}
+
+// --- Contact export types ---
+
+export type ContactExportStatus = "started" | "created" | "finished";
+
+export interface ContactExport {
+  id: number;
+  status: ContactExportStatus;
+  created_at: string;
+  updated_at: string;
+  url: string | null;
+}
+
+export type ContactExportFilterOperator =
+  | "equal"
+  | "not_equal"
+  | "contains"
+  | "not_contains"
+  | "is_empty"
+  | "is_not_empty";
+
+export type ContactExportFilterValue =
+  | string
+  | number
+  | boolean
+  | string[]
+  | number[];
+
+export interface ContactExportFilter {
+  name: string;
+  operator: ContactExportFilterOperator;
+  value: ContactExportFilterValue;
+}
+
+export interface CreateContactExportRequest {
+  filters: ContactExportFilter[];
+}
+
+export interface GetContactExportRequest {
+  export_id: number;
+}


### PR DESCRIPTION
## Motivation


## Changes
- create-contact-import — bulk-import contacts (returns an import job)
- get-contact-import — get import job status + created/updated/over-limit counts
- create-contact-export — export contacts matching AND-combined filters (returns an export job)
- get-contact-export — get export job status; url is populated when finished



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added contact import (bulk uploads) with job status polling.
  * Added contact export (filter-based exports) with job polling and CSV download URL when ready.

* **Documentation**
  * Documented import payload shape and export filter structure, including operator/value behavior.

* **Tests**
  * Added test coverage for create/get contact import and export workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailtrap/mailtrap-mcp/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->