### PR TITLE
Add missing organization tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,5 +182,6 @@ Schema files define a JSON Schema–shaped object for MCP; optional Zod schemas 
 #### Organizations
 
 - **list-sub-accounts**: List sub-accounts in the organization (requires `MAILTRAP_ORGANIZATION_ID`).
+- **create-sub-account**: Create a sub-account under the organization (requires `MAILTRAP_ORGANIZATION_ID`).
 
 Tools use input schemas (JSON Schema format) for MCP; handlers may validate input with Zod. Response format follows the MCP protocol.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,4 +178,9 @@ Schema files define a JSON Schema–shaped object for MCP; optional Zod schemas 
 - **reset-api-token**: Rotate an API token. Response includes the new secret `token` value; previous one is invalidated.
 - **delete-api-token**: Permanently delete an API token by ID.
 
+
+#### Organizations
+
+- **list-sub-accounts**: List sub-accounts in the organization (requires `MAILTRAP_ORGANIZATION_ID`).
+
 Tools use input schemas (JSON Schema format) for MCP; handlers may validate input with Zod. Response format follows the MCP protocol.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Before using this MCP server, you need to:
 - `DEFAULT_FROM_EMAIL` - Default sender email when `from` is not provided to send-email or send-sandbox-email. Enables switching sender per call via the `from` parameter.
 - `MAILTRAP_TEST_INBOX_ID` - Default test inbox ID for sandbox tools when `test_inbox_id` is not provided. Enables switching between inboxes per call via the `test_inbox_id` parameter.
 - `MAILTRAP_SANDBOX_ID` - Default sandbox ID for sandbox tools when `sandbox_id` is not provided. Enables switching between sandboxes per call via the `sandbox_id` parameter.
+- `MAILTRAP_ORGANIZATION_ID` - Required for organization tools (`list-sub-accounts`, `create-sub-account`).
 
 ## Quick Install
 

--- a/README.md
+++ b/README.md
@@ -881,7 +881,7 @@ Bulk create, update, or destroy permissions for a single account access. Existin
 - `permissions` (required): Array of permission entries. Each has:
   - `resource_id` (required): Resource ID (number or string)
   - `resource_type` (required): One of `account`, `project`, `inbox`, `sending_domain`, `billing`, `mailsend_domain`
-  - `access_level` (optional): `admin`/`100` or `viewer`/`10`
+  - `access_level` (optional): `100` (admin) or `10` (viewer)
   - `destroy` (optional, boolean): When true, removes this permission instead of creating/updating it
 
 ### list-api-tokens

--- a/README.md
+++ b/README.md
@@ -927,6 +927,14 @@ Permanently delete an API token by ID. The token can no longer authenticate afte
 
 - `api_token_id` (required): ID of the API token to delete
 
+### list-sub-accounts
+
+List sub-accounts in the organization. Requires `MAILTRAP_ORGANIZATION_ID` env var and sub-account management permissions.
+
+**Parameters:**
+
+- No parameters required
+
 ## Development
 
 1. Clone the repository:

--- a/README.md
+++ b/README.md
@@ -935,6 +935,14 @@ List sub-accounts in the organization. Requires `MAILTRAP_ORGANIZATION_ID` env v
 
 - No parameters required
 
+### create-sub-account
+
+Create a new sub-account under the organization. Requires `MAILTRAP_ORGANIZATION_ID` env var and sub-account management permissions.
+
+**Parameters:**
+
+- `name` (required): Display name for the new sub-account
+
 ## Development
 
 1. Clone the repository:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Before using this MCP server, you need to:
 - `MAILTRAP_TEST_INBOX_ID` - Default test inbox ID for sandbox tools when `test_inbox_id` is not provided. Enables switching between inboxes per call via the `test_inbox_id` parameter.
 - `MAILTRAP_SANDBOX_ID` - Default sandbox ID for sandbox tools when `sandbox_id` is not provided. Enables switching between sandboxes per call via the `sandbox_id` parameter.
 - `MAILTRAP_ORGANIZATION_ID` - Required for organization tools (`list-sub-accounts`, `create-sub-account`).
+- `MAILTRAP_ORGANIZATION_API_TOKEN` - Organization-scoped API token. Required for organization tools (separate from `MAILTRAP_API_TOKEN`).
 
 ## Quick Install
 

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,0 +1,68 @@
+import { getOrganizationClient } from "../client";
+
+describe("getOrganizationClient", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.MAILTRAP_ORGANIZATION_API_TOKEN = "test-token";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("returns a client when organization ID is a positive integer", () => {
+    process.env.MAILTRAP_ORGANIZATION_ID = "42";
+
+    expect(() => getOrganizationClient()).not.toThrow();
+  });
+
+  it("rejects a missing organization ID", () => {
+    delete process.env.MAILTRAP_ORGANIZATION_ID;
+
+    expect(() => getOrganizationClient()).toThrow(
+      /MAILTRAP_ORGANIZATION_ID environment variable is required/
+    );
+  });
+
+  it("rejects a non-numeric organization ID", () => {
+    process.env.MAILTRAP_ORGANIZATION_ID = "not-a-number";
+
+    expect(() => getOrganizationClient()).toThrow(
+      /MAILTRAP_ORGANIZATION_ID environment variable is required/
+    );
+  });
+
+  it("rejects zero", () => {
+    process.env.MAILTRAP_ORGANIZATION_ID = "0";
+
+    expect(() => getOrganizationClient()).toThrow(
+      /MAILTRAP_ORGANIZATION_ID environment variable is required/
+    );
+  });
+
+  it("rejects a decimal organization ID", () => {
+    process.env.MAILTRAP_ORGANIZATION_ID = "1.5";
+
+    expect(() => getOrganizationClient()).toThrow(
+      /MAILTRAP_ORGANIZATION_ID environment variable is required/
+    );
+  });
+
+  it("rejects a negative organization ID", () => {
+    process.env.MAILTRAP_ORGANIZATION_ID = "-1";
+
+    expect(() => getOrganizationClient()).toThrow(
+      /MAILTRAP_ORGANIZATION_ID environment variable is required/
+    );
+  });
+
+  it("rejects a missing organization API token", () => {
+    delete process.env.MAILTRAP_ORGANIZATION_API_TOKEN;
+    process.env.MAILTRAP_ORGANIZATION_ID = "42";
+
+    expect(() => getOrganizationClient()).toThrow(
+      /MAILTRAP_ORGANIZATION_API_TOKEN environment variable is required/
+    );
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -14,11 +14,6 @@ const client = (
         !Number.isNaN(Number(process.env.MAILTRAP_ACCOUNT_ID))
           ? { accountId: Number(process.env.MAILTRAP_ACCOUNT_ID) }
           : {}),
-        // conditionally set organizationId if it's a valid number
-        ...(process.env.MAILTRAP_ORGANIZATION_ID &&
-        !Number.isNaN(Number(process.env.MAILTRAP_ORGANIZATION_ID))
-          ? { organizationId: Number(process.env.MAILTRAP_ORGANIZATION_ID) }
-          : {}),
       })
     : null
 ) as MailtrapClient;
@@ -44,23 +39,44 @@ function getSandboxClient(inboxId: number): MailtrapClient {
 }
 
 /**
+ * Returns an organization-scoped MailtrapClient. Organization endpoints
+ * require a dedicated organization-level API token; both
+ * MAILTRAP_ORGANIZATION_API_TOKEN and MAILTRAP_ORGANIZATION_ID must be set.
+ */
+function getOrganizationClient(): MailtrapClient {
+  const token = process.env.MAILTRAP_ORGANIZATION_API_TOKEN;
+  if (!token) {
+    throw new Error(
+      "MAILTRAP_ORGANIZATION_API_TOKEN environment variable is required for organization tools"
+    );
+  }
+  const organizationId = process.env.MAILTRAP_ORGANIZATION_ID;
+  if (!organizationId || Number.isNaN(Number(organizationId))) {
+    throw new Error(
+      "MAILTRAP_ORGANIZATION_ID environment variable is required for organization tools"
+    );
+  }
+  return new MailtrapClient({
+    token,
+    userAgent: config.USER_AGENT,
+    organizationId: Number(organizationId),
+  });
+}
+
+/**
  * Validates that the Mailtrap client is initialised and (optionally) that
- * MAILTRAP_ACCOUNT_ID and/or MAILTRAP_ORGANIZATION_ID are set. Returns the
- * client so callers can use it directly:
+ * MAILTRAP_ACCOUNT_ID is set.  Returns the client so callers can use it
+ * directly:
  *
  *   const mailtrap = requireClient("sandbox projects");
  *   const projects = await mailtrap.testing.projects.getList();
  *
  * @param feature  Human-readable label used in error messages, e.g. "sandbox inboxes".
- * @param opts.requireAccountId       When true (default), assert MAILTRAP_ACCOUNT_ID.
- * @param opts.requireOrganizationId  When true, assert MAILTRAP_ORGANIZATION_ID.
+ * @param opts.requireAccountId  When true (the default), also assert MAILTRAP_ACCOUNT_ID.
  */
 function requireClient(
   feature: string,
-  {
-    requireAccountId = true,
-    requireOrganizationId = false,
-  }: { requireAccountId?: boolean; requireOrganizationId?: boolean } = {}
+  { requireAccountId = true }: { requireAccountId?: boolean } = {}
 ): MailtrapClient {
   if (!client) {
     throw new Error("MAILTRAP_API_TOKEN environment variable is required");
@@ -73,16 +89,8 @@ function requireClient(
       );
     }
   }
-  if (requireOrganizationId) {
-    const organizationId = process.env.MAILTRAP_ORGANIZATION_ID;
-    if (!organizationId || Number.isNaN(Number(organizationId))) {
-      throw new Error(
-        `MAILTRAP_ORGANIZATION_ID environment variable is required for ${feature}`
-      );
-    }
-  }
   return client;
 }
 
 // eslint-disable-next-line import/prefer-default-export
-export { client, getSandboxClient, requireClient };
+export { client, getSandboxClient, getOrganizationClient, requireClient };

--- a/src/client.ts
+++ b/src/client.ts
@@ -14,6 +14,11 @@ const client = (
         !Number.isNaN(Number(process.env.MAILTRAP_ACCOUNT_ID))
           ? { accountId: Number(process.env.MAILTRAP_ACCOUNT_ID) }
           : {}),
+        // conditionally set organizationId if it's a valid number
+        ...(process.env.MAILTRAP_ORGANIZATION_ID &&
+        !Number.isNaN(Number(process.env.MAILTRAP_ORGANIZATION_ID))
+          ? { organizationId: Number(process.env.MAILTRAP_ORGANIZATION_ID) }
+          : {}),
       })
     : null
 ) as MailtrapClient;
@@ -40,18 +45,22 @@ function getSandboxClient(inboxId: number): MailtrapClient {
 
 /**
  * Validates that the Mailtrap client is initialised and (optionally) that
- * MAILTRAP_ACCOUNT_ID is set.  Returns the client so callers can use it
- * directly:
+ * MAILTRAP_ACCOUNT_ID and/or MAILTRAP_ORGANIZATION_ID are set. Returns the
+ * client so callers can use it directly:
  *
  *   const mailtrap = requireClient("sandbox projects");
  *   const projects = await mailtrap.testing.projects.getList();
  *
  * @param feature  Human-readable label used in error messages, e.g. "sandbox inboxes".
- * @param opts.requireAccountId  When true (the default), also assert MAILTRAP_ACCOUNT_ID.
+ * @param opts.requireAccountId       When true (default), assert MAILTRAP_ACCOUNT_ID.
+ * @param opts.requireOrganizationId  When true, assert MAILTRAP_ORGANIZATION_ID.
  */
 function requireClient(
   feature: string,
-  { requireAccountId = true }: { requireAccountId?: boolean } = {}
+  {
+    requireAccountId = true,
+    requireOrganizationId = false,
+  }: { requireAccountId?: boolean; requireOrganizationId?: boolean } = {}
 ): MailtrapClient {
   if (!client) {
     throw new Error("MAILTRAP_API_TOKEN environment variable is required");
@@ -61,6 +70,14 @@ function requireClient(
     if (!accountId || Number.isNaN(Number(accountId))) {
       throw new Error(
         `MAILTRAP_ACCOUNT_ID environment variable is required for ${feature}`
+      );
+    }
+  }
+  if (requireOrganizationId) {
+    const organizationId = process.env.MAILTRAP_ORGANIZATION_ID;
+    if (!organizationId || Number.isNaN(Number(organizationId))) {
+      throw new Error(
+        `MAILTRAP_ORGANIZATION_ID environment variable is required for ${feature}`
       );
     }
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -51,7 +51,12 @@ function getOrganizationClient(): MailtrapClient {
     );
   }
   const organizationId = process.env.MAILTRAP_ORGANIZATION_ID;
-  if (!organizationId || Number.isNaN(Number(organizationId))) {
+  const parsedOrganizationId = Number(organizationId);
+  if (
+    !organizationId ||
+    !Number.isInteger(parsedOrganizationId) ||
+    parsedOrganizationId <= 0
+  ) {
     throw new Error(
       "MAILTRAP_ORGANIZATION_ID environment variable is required for organization tools"
     );
@@ -59,7 +64,7 @@ function getOrganizationClient(): MailtrapClient {
   return new MailtrapClient({
     token,
     userAgent: config.USER_AGENT,
-    organizationId: Number(organizationId),
+    organizationId: parsedOrganizationId,
   });
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -188,7 +188,12 @@ import {
   resetApiToken,
   deleteApiToken,
 } from "./tools/apiTokens";
-import { listSubAccounts, listSubAccountsSchema } from "./tools/organizations";
+import {
+  listSubAccounts,
+  listSubAccountsSchema,
+  createSubAccount,
+  createSubAccountSchema,
+} from "./tools/organizations";
 
 // Define the tools registry
 const tools = [
@@ -983,6 +988,16 @@ const tools = [
     handler: listSubAccounts,
     annotations: {
       readOnlyHint: true,
+    },
+  },
+  {
+    name: "create-sub-account",
+    description:
+      "Create a new sub-account under the organization. Requires `MAILTRAP_ORGANIZATION_ID` and sub-account management permissions.",
+    inputSchema: createSubAccountSchema,
+    handler: createSubAccount,
+    annotations: {
+      destructiveHint: true,
     },
   },
 ];

--- a/src/server.ts
+++ b/src/server.ts
@@ -188,6 +188,7 @@ import {
   resetApiToken,
   deleteApiToken,
 } from "./tools/apiTokens";
+import { listSubAccounts, listSubAccountsSchema } from "./tools/organizations";
 
 // Define the tools registry
 const tools = [
@@ -972,6 +973,16 @@ const tools = [
     handler: deleteApiToken,
     annotations: {
       destructiveHint: true,
+    },
+  },
+  {
+    name: "list-sub-accounts",
+    description:
+      "List sub-accounts in the organization. Requires `MAILTRAP_ORGANIZATION_ID` env var and sub-account management permissions.",
+    inputSchema: listSubAccountsSchema,
+    handler: listSubAccounts,
+    annotations: {
+      readOnlyHint: true,
     },
   },
 ];

--- a/src/tools/organizations/__tests__/createSubAccount.test.ts
+++ b/src/tools/organizations/__tests__/createSubAccount.test.ts
@@ -1,0 +1,54 @@
+import createSubAccount from "../createSubAccount";
+import { requireClient } from "../../../client";
+
+const mockClient = {
+  organizations: {
+    subAccounts: {
+      create: jest.fn(),
+    },
+  },
+};
+
+jest.mock("../../../client", () => ({
+  requireClient: jest.fn(() => mockClient),
+}));
+
+describe("createSubAccount", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  it("creates a sub-account and returns the result as JSON", async () => {
+    mockClient.organizations.subAccounts.create.mockResolvedValue({
+      id: 99,
+      name: "QA Sub",
+    });
+
+    const result = await createSubAccount({ name: "QA Sub" });
+
+    expect(requireClient).toHaveBeenCalledWith("sub-accounts", {
+      requireAccountId: false,
+      requireOrganizationId: true,
+    });
+    expect(mockClient.organizations.subAccounts.create).toHaveBeenCalledWith({
+      name: "QA Sub",
+    });
+    expect(result.content[0].text).toContain('"id": 99');
+    expect(result.content[0].text).toContain('"name": "QA Sub"');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("surfaces API errors", async () => {
+    mockClient.organizations.subAccounts.create.mockRejectedValue(
+      new Error("name taken")
+    );
+
+    const result = await createSubAccount({ name: "Dup" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to create sub-account: name taken"
+    );
+  });
+});

--- a/src/tools/organizations/__tests__/createSubAccount.test.ts
+++ b/src/tools/organizations/__tests__/createSubAccount.test.ts
@@ -1,5 +1,5 @@
 import createSubAccount from "../createSubAccount";
-import { requireClient } from "../../../client";
+import { getOrganizationClient } from "../../../client";
 
 const mockClient = {
   organizations: {
@@ -10,16 +10,16 @@ const mockClient = {
 };
 
 jest.mock("../../../client", () => ({
-  requireClient: jest.fn(() => mockClient),
+  getOrganizationClient: jest.fn(() => mockClient),
 }));
 
 describe("createSubAccount", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (requireClient as jest.Mock).mockReturnValue(mockClient);
+    (getOrganizationClient as jest.Mock).mockReturnValue(mockClient);
   });
 
-  it("creates a sub-account and returns the result as JSON", async () => {
+  it("creates a sub-account via the organization client and returns JSON", async () => {
     mockClient.organizations.subAccounts.create.mockResolvedValue({
       id: 99,
       name: "QA Sub",
@@ -27,10 +27,7 @@ describe("createSubAccount", () => {
 
     const result = await createSubAccount({ name: "QA Sub" });
 
-    expect(requireClient).toHaveBeenCalledWith("sub-accounts", {
-      requireAccountId: false,
-      requireOrganizationId: true,
-    });
+    expect(getOrganizationClient).toHaveBeenCalledWith();
     expect(mockClient.organizations.subAccounts.create).toHaveBeenCalledWith({
       name: "QA Sub",
     });

--- a/src/tools/organizations/__tests__/listSubAccounts.test.ts
+++ b/src/tools/organizations/__tests__/listSubAccounts.test.ts
@@ -1,0 +1,71 @@
+import listSubAccounts from "../listSubAccounts";
+import { requireClient } from "../../../client";
+
+const mockClient = {
+  organizations: {
+    subAccounts: {
+      getList: jest.fn(),
+    },
+  },
+};
+
+jest.mock("../../../client", () => ({
+  requireClient: jest.fn(() => mockClient),
+}));
+
+describe("listSubAccounts", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireClient as jest.Mock).mockReturnValue(mockClient);
+  });
+
+  it("requires the organization ID and returns sub-accounts as JSON", async () => {
+    mockClient.organizations.subAccounts.getList.mockResolvedValue([
+      { id: 1, name: "Sub A" },
+      { id: 2, name: "Sub B" },
+    ]);
+
+    const result = await listSubAccounts();
+
+    expect(requireClient).toHaveBeenCalledWith("sub-accounts", {
+      requireAccountId: false,
+      requireOrganizationId: true,
+    });
+    expect(result.content[0].text).toContain('"id": 1');
+    expect(result.content[0].text).toContain('"name": "Sub B"');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("returns empty message when no sub-accounts exist", async () => {
+    mockClient.organizations.subAccounts.getList.mockResolvedValue([]);
+
+    const result = await listSubAccounts();
+
+    expect(result.content[0].text).toBe(
+      "No sub-accounts in this organization."
+    );
+  });
+
+  it("handles null response", async () => {
+    mockClient.organizations.subAccounts.getList.mockResolvedValue(null);
+
+    const result = await listSubAccounts();
+
+    expect(result.content[0].text).toBe(
+      "No sub-accounts in this organization."
+    );
+  });
+
+  it("surfaces API errors", async () => {
+    mockClient.organizations.subAccounts.getList.mockRejectedValue(
+      new Error("forbidden")
+    );
+
+    const result = await listSubAccounts();
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to list sub-accounts: forbidden"
+    );
+  });
+});

--- a/src/tools/organizations/__tests__/listSubAccounts.test.ts
+++ b/src/tools/organizations/__tests__/listSubAccounts.test.ts
@@ -1,5 +1,5 @@
 import listSubAccounts from "../listSubAccounts";
-import { requireClient } from "../../../client";
+import { getOrganizationClient } from "../../../client";
 
 const mockClient = {
   organizations: {
@@ -10,16 +10,16 @@ const mockClient = {
 };
 
 jest.mock("../../../client", () => ({
-  requireClient: jest.fn(() => mockClient),
+  getOrganizationClient: jest.fn(() => mockClient),
 }));
 
 describe("listSubAccounts", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (requireClient as jest.Mock).mockReturnValue(mockClient);
+    (getOrganizationClient as jest.Mock).mockReturnValue(mockClient);
   });
 
-  it("requires the organization ID and returns sub-accounts as JSON", async () => {
+  it("returns sub-accounts as JSON via the organization client", async () => {
     mockClient.organizations.subAccounts.getList.mockResolvedValue([
       { id: 1, name: "Sub A" },
       { id: 2, name: "Sub B" },
@@ -27,10 +27,7 @@ describe("listSubAccounts", () => {
 
     const result = await listSubAccounts();
 
-    expect(requireClient).toHaveBeenCalledWith("sub-accounts", {
-      requireAccountId: false,
-      requireOrganizationId: true,
-    });
+    expect(getOrganizationClient).toHaveBeenCalledWith();
     expect(result.content[0].text).toContain('"id": 1');
     expect(result.content[0].text).toContain('"name": "Sub B"');
     expect(result.isError).toBeUndefined();

--- a/src/tools/organizations/createSubAccount.ts
+++ b/src/tools/organizations/createSubAccount.ts
@@ -1,4 +1,4 @@
-import { requireClient } from "../../client";
+import { getOrganizationClient } from "../../client";
 import { CreateSubAccountRequest, SubAccount } from "../../types/mailtrap";
 import {
   buildErrorResponse,
@@ -10,10 +10,7 @@ async function createSubAccount({
   name,
 }: CreateSubAccountRequest): Promise<ToolResponse> {
   try {
-    const mailtrap = requireClient("sub-accounts", {
-      requireAccountId: false,
-      requireOrganizationId: true,
-    });
+    const mailtrap = getOrganizationClient();
 
     const response = (await mailtrap.organizations.subAccounts.create({
       name,

--- a/src/tools/organizations/createSubAccount.ts
+++ b/src/tools/organizations/createSubAccount.ts
@@ -1,0 +1,28 @@
+import { requireClient } from "../../client";
+import { CreateSubAccountRequest, SubAccount } from "../../types/mailtrap";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
+
+async function createSubAccount({
+  name,
+}: CreateSubAccountRequest): Promise<ToolResponse> {
+  try {
+    const mailtrap = requireClient("sub-accounts", {
+      requireAccountId: false,
+      requireOrganizationId: true,
+    });
+
+    const response = (await mailtrap.organizations.subAccounts.create({
+      name,
+    })) as SubAccount;
+
+    return buildSuccessResponse(JSON.stringify(response, null, 2));
+  } catch (error) {
+    return buildErrorResponse("create sub-account", error);
+  }
+}
+
+export default createSubAccount;

--- a/src/tools/organizations/index.ts
+++ b/src/tools/organizations/index.ts
@@ -1,4 +1,11 @@
 import listSubAccountsSchema from "./schemas/listSubAccounts";
 import listSubAccounts from "./listSubAccounts";
+import createSubAccountSchema from "./schemas/createSubAccount";
+import createSubAccount from "./createSubAccount";
 
-export { listSubAccountsSchema, listSubAccounts };
+export {
+  listSubAccountsSchema,
+  listSubAccounts,
+  createSubAccountSchema,
+  createSubAccount,
+};

--- a/src/tools/organizations/index.ts
+++ b/src/tools/organizations/index.ts
@@ -1,0 +1,4 @@
+import listSubAccountsSchema from "./schemas/listSubAccounts";
+import listSubAccounts from "./listSubAccounts";
+
+export { listSubAccountsSchema, listSubAccounts };

--- a/src/tools/organizations/listSubAccounts.ts
+++ b/src/tools/organizations/listSubAccounts.ts
@@ -1,4 +1,4 @@
-import { requireClient } from "../../client";
+import { getOrganizationClient } from "../../client";
 import { SubAccount } from "../../types/mailtrap";
 import {
   buildErrorResponse,
@@ -8,10 +8,7 @@ import {
 
 async function listSubAccounts(): Promise<ToolResponse> {
   try {
-    const mailtrap = requireClient("sub-accounts", {
-      requireAccountId: false,
-      requireOrganizationId: true,
-    });
+    const mailtrap = getOrganizationClient();
 
     const subAccounts = (await mailtrap.organizations.subAccounts.getList()) as
       | SubAccount[]

--- a/src/tools/organizations/listSubAccounts.ts
+++ b/src/tools/organizations/listSubAccounts.ts
@@ -1,0 +1,31 @@
+import { requireClient } from "../../client";
+import { SubAccount } from "../../types/mailtrap";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
+
+async function listSubAccounts(): Promise<ToolResponse> {
+  try {
+    const mailtrap = requireClient("sub-accounts", {
+      requireAccountId: false,
+      requireOrganizationId: true,
+    });
+
+    const subAccounts = (await mailtrap.organizations.subAccounts.getList()) as
+      | SubAccount[]
+      | null
+      | undefined;
+
+    if (!subAccounts || subAccounts.length === 0) {
+      return buildSuccessResponse("No sub-accounts in this organization.");
+    }
+
+    return buildSuccessResponse(JSON.stringify(subAccounts, null, 2));
+  } catch (error) {
+    return buildErrorResponse("list sub-accounts", error);
+  }
+}
+
+export default listSubAccounts;

--- a/src/tools/organizations/schemas/createSubAccount.ts
+++ b/src/tools/organizations/schemas/createSubAccount.ts
@@ -1,0 +1,13 @@
+const createSubAccountSchema = {
+  type: "object",
+  properties: {
+    name: {
+      type: "string",
+      description: "Display name for the new sub-account.",
+    },
+  },
+  required: ["name"],
+  additionalProperties: false,
+};
+
+export default createSubAccountSchema;

--- a/src/tools/organizations/schemas/listSubAccounts.ts
+++ b/src/tools/organizations/schemas/listSubAccounts.ts
@@ -1,0 +1,7 @@
+const listSubAccountsSchema = {
+  type: "object",
+  properties: {},
+  additionalProperties: false,
+};
+
+export default listSubAccountsSchema;

--- a/src/tools/permissions/__tests__/bulkUpdatePermissions.test.ts
+++ b/src/tools/permissions/__tests__/bulkUpdatePermissions.test.ts
@@ -19,7 +19,7 @@ describe("bulkUpdatePermissions", () => {
     (requireClient as jest.Mock).mockReturnValue(mockClient);
   });
 
-  it("translates snake_case permissions to SDK camelCase shape", async () => {
+  it("forwards permissions to the SDK in the shape it expects", async () => {
     mockClient.general.permissions.bulkPermissionsUpdate.mockResolvedValue([
       { id: 1, name: "Project A", type: "project", access_level: 100 },
     ]);
@@ -27,11 +27,7 @@ describe("bulkUpdatePermissions", () => {
     const result = await bulkUpdatePermissions({
       account_access_id: 42,
       permissions: [
-        {
-          resource_id: 100,
-          resource_type: "project",
-          access_level: "admin",
-        },
+        { resource_id: 100, resource_type: "project", access_level: 100 },
         {
           resource_id: "uuid-1",
           resource_type: "sending_domain",
@@ -44,19 +40,28 @@ describe("bulkUpdatePermissions", () => {
     expect(
       mockClient.general.permissions.bulkPermissionsUpdate
     ).toHaveBeenCalledWith(42, [
-      {
-        resourceId: "100",
-        resourceType: "project",
-        accessLevel: "admin",
-      },
-      {
-        resourceId: "uuid-1",
-        resourceType: "sending_domain",
-        destroy: "true",
-      },
+      { resourceId: "100", resourceType: "project", accessLevel: "100" },
+      { resourceId: "uuid-1", resourceType: "sending_domain", destroy: "true" },
     ]);
     expect(result.content[0].text).toContain('"access_level": 100');
     expect(result.isError).toBeUndefined();
+  });
+
+  it("accepts string access_level values", async () => {
+    mockClient.general.permissions.bulkPermissionsUpdate.mockResolvedValue([]);
+
+    await bulkUpdatePermissions({
+      account_access_id: 42,
+      permissions: [
+        { resource_id: 100, resource_type: "project", access_level: "viewer" },
+      ],
+    });
+
+    expect(
+      mockClient.general.permissions.bulkPermissionsUpdate
+    ).toHaveBeenCalledWith(42, [
+      { resourceId: "100", resourceType: "project", accessLevel: "viewer" },
+    ]);
   });
 
   it("surfaces API errors", async () => {
@@ -66,7 +71,9 @@ describe("bulkUpdatePermissions", () => {
 
     const result = await bulkUpdatePermissions({
       account_access_id: 42,
-      permissions: [{ resource_id: 1, resource_type: "project" }],
+      permissions: [
+        { resource_id: 1, resource_type: "project", access_level: 10 },
+      ],
     });
 
     expect(result.isError).toBe(true);

--- a/src/tools/permissions/bulkUpdatePermissions.ts
+++ b/src/tools/permissions/bulkUpdatePermissions.ts
@@ -16,7 +16,9 @@ async function bulkUpdatePermissions({
     const sdkPermissions = permissions.map((p) => ({
       resourceId: String(p.resource_id),
       resourceType: p.resource_type,
-      ...(p.access_level !== undefined && { accessLevel: p.access_level }),
+      ...(p.access_level !== undefined && {
+        accessLevel: String(p.access_level),
+      }),
       ...(p.destroy !== undefined && { destroy: String(p.destroy) }),
     }));
 

--- a/src/tools/permissions/schemas/bulkUpdatePermissions.ts
+++ b/src/tools/permissions/schemas/bulkUpdatePermissions.ts
@@ -30,10 +30,10 @@ const bulkUpdatePermissionsSchema = {
             description: "Type of resource.",
           },
           access_level: {
-            type: "string",
-            enum: ["admin", "viewer", "100", "10"],
+            type: ["number", "string"],
+            enum: [10, 100, "admin", "viewer"],
             description:
-              "Access level. `admin`/`100` for admin, `viewer`/`10` for viewer.",
+              "Access level: 100 or `admin` for admin, 10 or `viewer` for viewer.",
           },
           destroy: {
             type: "boolean",

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -597,7 +597,7 @@ export type PermissionResourceType =
 export interface PermissionUpdateItem {
   resource_id: number | string;
   resource_type: PermissionResourceType;
-  access_level?: "admin" | "viewer" | "100" | "10";
+  access_level?: 10 | 100 | "admin" | "viewer";
   destroy?: boolean;
 }
 

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -622,3 +622,14 @@ export interface CreateApiTokenRequest {
 export interface ApiTokenRequest {
   api_token_id: number;
 }
+
+// --- Organization / sub-account types ---
+
+export interface SubAccount {
+  id: number;
+  name: string;
+}
+
+export interface CreateSubAccountRequest {
+  name: string;
+}


### PR DESCRIPTION
## Motivation


## Changes  
  - list-sub-accounts — list sub-accounts in the organization (requires MAILTRAP_ORGANIZATION_ID env var and sub-account management permissions)
  - create-sub-account — create a new sub-account under the organization with a name (requires MAILTRAP_ORGANIZATION_ID env var and sub-account management
  permissions)
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization-level sub-account management tools: list and create sub-accounts.

* **Improvements**
  * Permission access levels now accept both numeric and string values for greater flexibility.

* **Documentation**
  * Added guides for new organization management tools and organization-scoped environment variable requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mailtrap/mailtrap-mcp/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->