### PR TITLE
Add mcpName and server.json for MCP Registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-08
+
+* Add `mcpName` and `server.json` for publishing to the official MCP Registry as `io.mailtrap/mcp`.
+
 ## [0.4.0] - 2026-05-11
 
 * Add **template-based sending** to **send-email** and **send-sandbox-email**: pass `template_uuid` (with optional `template_variables`) to send via a Mailtrap template. Per the Mailtrap API, when `template_uuid` is set, `subject`, `text`, `html`, and `category` must be omitted; this is enforced at runtime. `subject` is no longer in the schema's `required` array since it does not apply to template sends. See https://github.com/mailtrap/mailtrap-mcp/pull/82

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "mailtrap-mcpb",
   "display_name": "Mailtrap",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Send emails and manage templates using Mailtrap",
   "long_description": "**[Mailtrap.io](https://mailtrap.io)** is a comprehensive email platform that helps developers and teams test, debug, and deliver emails safely. It provides both email testing (sandbox) and email delivery services. \n This MCP (Model Context Protocol) server provides AI assistants with the ability to: \n - **Send emails** via Mailtrap's delivery API \n - **Test emails** using Mailtrap's sandbox environment \n - **Manage email templates** (create, update, delete, list).",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-mailtrap",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-mailtrap",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mcp-mailtrap",
-  "version": "0.4.0",
+  "version": "0.4.1",
+  "mcpName": "io.mailtrap/mcp",
   "description": "Official MCP Server for Mailtrap",
   "license": "MIT",
   "author": "Railsware Products Studio LLC",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.mailtrap/mcp",
+  "description": "Official MCP Server for Mailtrap",
+  "title": "Mailtrap",
+  "websiteUrl": "https://docs.mailtrap.io/guides/ai-powered-integrations/mcp-server",
+  "repository": {
+    "url": "https://github.com/mailtrap/mailtrap-mcp",
+    "source": "github"
+  },
+  "version": "0.4.1",
+  "icons": [
+    {
+      "src": "https://raw.githubusercontent.com/mailtrap/mailtrap-mcp/main/icon.png",
+      "mimeType": "image/png"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "mcp-mailtrap",
+      "version": "0.4.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "MAILTRAP_API_TOKEN",
+          "description": "Mailtrap API token from https://mailtrap.io/api-tokens",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "MAILTRAP_ACCOUNT_ID",
+          "description": "Mailtrap account ID from https://mailtrap.io/account-management",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,5 @@
 export default {
   MCP_SERVER_NAME: "mailtrap-mcp-server",
-  MCP_SERVER_VERSION: "0.4.0",
+  MCP_SERVER_VERSION: "0.4.1",
   USER_AGENT: "mailtrap-mcp (https://github.com/mailtrap/mailtrap-mcp)",
 };


### PR DESCRIPTION
## Changes

- Add `mcpName: "io.mailtrap/mcp"` to `package.json` for npm package-ownership proof
- Add root `server.json` with npm stdio transport and env var declarations
- Bump version to `0.4.1` across `package.json`, `manifest.json`, and `src/config/index.ts`

## How to test

No QA needed — registry manifest and npm metadata only, no runtime behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: Version 0.4.1

* **Chores**
  * Released version 0.4.1
  * Added server registry configuration with environment variable setup for API token and account credentials
  * Updated package metadata across configuration files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->