### PR TITLE
Add placeholder for draft SDK release

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,28 @@
+# Placeholder draft-release workflow for Mailtrap SDKs.
+#
+name: Draft SDK Release
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: "Semver bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+
+jobs:
+  draft-release:
+    name: Draft SDK Release (placeholder)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo inputs
+        env:
+          BUMP_TYPE: ${{ inputs.bump_type }}
+          SDK: ${{ inputs.sdk }}
+        run: |
+          echo "Placeholder draft-release workflow"
+          echo "bump_type=$BUMP_TYPE"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Echo inputs
         env:
           BUMP_TYPE: ${{ inputs.bump_type }}
-          SDK: ${{ inputs.sdk }}
         run: |
           echo "Placeholder draft-release workflow"
           echo "bump_type=$BUMP_TYPE"


### PR DESCRIPTION
## Motivation

Lock in the workflow file path, name and trigger surface for the SDK draft-release automation so I'll be able to trigger the workflow during the implementation.

## Changes

- Add `.github/workflows/draft-release.yml` as a no-op placeholder.
- Trigger: `workflow_dispatch` with `bump_type` (`patch | minor | major`)
- Single job that echoes the inputs and exits 0.

## How to test

- [ ] Workflow appears under Actions → "Draft Release" with choice inputs.
- [ ] Manual run echoes the selected inputs and completes successfully (exit 0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new manual “Draft SDK Release” workflow that lets you choose a version bump type (patch, minor, or major) and logs the selected option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->