### PR TITLE
Implement draft-release workflow

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -166,9 +166,7 @@ jobs:
             const original = fs.readFileSync('CHANGELOG.md', 'utf8');
             fs.writeFileSync('CHANGELOG.md', entry + original);
 
-      - name: Commit, push, open PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Commit and push release branch
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -176,10 +174,22 @@ jobs:
           git add package.json package-lock.json src/config/version.ts manifest.json server.json CHANGELOG.md
           git commit -m "Release ${{ steps.bump.outputs.tag }}"
           git push -u origin "${{ steps.bump.outputs.branch }}"
-          gh pr create \
-            --base main \
-            --head "${{ steps.bump.outputs.branch }}" \
-            --title "Release ${{ steps.bump.outputs.tag }}" \
-            --body "Automated release prep (\`${{ inputs.bump_type }}\` bump from v${{ steps.bump.outputs.current }}).
 
-          Review the CHANGELOG diff. On merge, create a GitHub release with the tag \`${{ steps.bump.outputs.tag }}\` to publish (npm + signed .mcpb)."
+      - name: Create draft GitHub release
+        uses: actions/github-script@v7
+        env:
+          BULLETS: ${{ steps.notes.outputs.bullets }}
+        with:
+          script: |
+            const tag = '${{ steps.bump.outputs.tag }}';
+            const { data } = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tag,
+              target_commitish: '${{ steps.bump.outputs.branch }}',
+              name: tag,
+              body: process.env.BULLETS,
+              draft: true,
+              prerelease: false,
+            });
+            core.info(`Draft release created: ${data.html_url}`);

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,4 +1,5 @@
-# Placeholder draft-release workflow for Mailtrap SDKs.
+# Drafts a new SDK release: bumps versions, regenerates the changelog from
+# merged PRs, and opens a release PR against main.
 #
 name: Draft SDK Release
 on:
@@ -14,15 +15,171 @@ on:
           - major
         default: patch
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   draft-release:
-    name: Draft SDK Release (placeholder)
+    name: Draft SDK Release
     runs-on: ubuntu-latest
     steps:
-      - name: Echo inputs
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .tool-versions
+
+      - name: Compute next version
+        id: bump
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const current = JSON.parse(fs.readFileSync('package.json', 'utf8')).version;
+            const [major, minor, patch] = current.split('.').map(Number);
+            const next = {
+              major: `${major + 1}.0.0`,
+              minor: `${major}.${minor + 1}.0`,
+              patch: `${major}.${minor}.${patch + 1}`,
+            }[context.payload.inputs.bump_type];
+            const tag = `v${next}`;
+
+            core.info(`Bumping ${current} -> ${next}`);
+            core.setOutput('current', current);
+            core.setOutput('next', next);
+            core.setOutput('tag', tag);
+            core.setOutput('branch', `release-${tag}`);
+
+      - name: Abort if tag already exists
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = '${{ steps.bump.outputs.tag }}';
+            try {
+              await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `tags/${tag}`,
+              });
+              core.setFailed(`Tag ${tag} already exists`);
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
+
+      - name: Update version in package.json
+        run: npm version --no-git-tag-version --allow-same-version "${{ steps.bump.outputs.next }}"
+
+      - name: Update version in src/config/version.ts
+        uses: actions/github-script@v7
         env:
-          BUMP_TYPE: ${{ inputs.bump_type }}
-          SDK: ${{ inputs.sdk }}
+          NEXT: ${{ steps.bump.outputs.next }}
+        with:
+          script: |
+            const fs = require('fs');
+            fs.writeFileSync(
+              'src/config/version.ts',
+              `export default ${JSON.stringify(process.env.NEXT)};\n`
+            );
+
+      - name: Update version in manifest.json
+        uses: actions/github-script@v7
+        env:
+          NEXT: ${{ steps.bump.outputs.next }}
+        with:
+          script: |
+            const fs = require('fs');
+            const manifest = JSON.parse(fs.readFileSync('manifest.json', 'utf8'));
+            manifest.version = process.env.NEXT;
+            fs.writeFileSync('manifest.json', JSON.stringify(manifest, null, 2) + '\n');
+
+      - name: Update version in server.json
+        uses: actions/github-script@v7
+        env:
+          NEXT: ${{ steps.bump.outputs.next }}
+        with:
+          script: |
+            const fs = require('fs');
+            const server = JSON.parse(fs.readFileSync('server.json', 'utf8'));
+            server.version = process.env.NEXT;
+            const pkg = (server.packages || []).find(
+              (p) => p.identifier === 'mcp-mailtrap'
+            );
+            if (!pkg) {
+              core.setFailed('No package with identifier "mcp-mailtrap" found in server.json');
+              return;
+            }
+            pkg.version = process.env.NEXT;
+            fs.writeFileSync('server.json', JSON.stringify(server, null, 2) + '\n');
+
+      - name: Generate release notes from PRs since last tag
+        id: notes
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = '${{ steps.bump.outputs.tag }}';
+
+            // Detect the previous release tag so notes only cover PRs since then.
+            let previousTag;
+            try {
+              const latest = await github.rest.repos.getLatestRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              previousTag = latest.data.tag_name;
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
+
+            const { data } = await github.rest.repos.generateReleaseNotes({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tag,
+              ...(previousTag ? { previous_tag_name: previousTag } : {}),
+            });
+
+            core.setOutput('raw_notes', data.body);
+
+            // Keep only the PR bullet lines; drop the "## What's Changed" header
+            // and the "**Full Changelog**" footer.
+            const bullets = data.body
+              .split('\n')
+              .filter((line) => line.trimStart().startsWith('*'))
+              .join('\n');
+            core.setOutput('bullets', bullets || '* No changes since previous release');
+
+      - name: Prepend new section to CHANGELOG.md
+        uses: actions/github-script@v7
+        env:
+          NEXT: ${{ steps.bump.outputs.next }}
+          BULLETS: ${{ steps.notes.outputs.bullets }}
+        with:
+          script: |
+            const fs = require('fs');
+            const version = process.env.NEXT;
+            const date = new Date().toISOString().slice(0, 10);
+            const bullets = process.env.BULLETS.trim();
+            const entry = `## [${version}] - ${date}\n\n${bullets}\n\n`;
+            const original = fs.readFileSync('CHANGELOG.md', 'utf8');
+            fs.writeFileSync('CHANGELOG.md', entry + original);
+
+      - name: Commit, push, open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Placeholder draft-release workflow"
-          echo "bump_type=$BUMP_TYPE"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${{ steps.bump.outputs.branch }}"
+          git add package.json package-lock.json src/config/version.ts manifest.json server.json CHANGELOG.md
+          git commit -m "Release ${{ steps.bump.outputs.tag }}"
+          git push -u origin "${{ steps.bump.outputs.branch }}"
+          gh pr create \
+            --base main \
+            --head "${{ steps.bump.outputs.branch }}" \
+            --title "Release ${{ steps.bump.outputs.tag }}" \
+            --body "Automated release prep (\`${{ inputs.bump_type }}\` bump from v${{ steps.bump.outputs.current }}).
+
+          Review the CHANGELOG diff. On merge, create a GitHub release with the tag \`${{ steps.bump.outputs.tag }}\` to publish (npm + signed .mcpb)."

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,4 +1,4 @@
-# Drafts a new SDK release: bumps versions, regenerates the changelog from
+# Drafts a new release: bumps versions, regenerates the changelog from
 # merged PRs, and opens a release PR against main.
 #
 name: Draft SDK Release
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   draft-release:
-    name: Draft SDK Release
+    name: Draft MCP Release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -15,6 +15,10 @@ on:
           - major
         default: patch
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write
@@ -141,32 +145,26 @@ jobs:
               ...(previousTag ? { previous_tag_name: previousTag } : {}),
             });
 
-            core.info('raw_notes', data.body);
-
-            // Keep only the PR bullet lines; drop the "## What's Changed" header
-            // and the "**Full Changelog**" footer.
-            const bullets = data.body
-              .split('\n')
-              .filter((line) => line.trimStart().startsWith('*'))
-              .join('\n');
-            core.setOutput('bullets', bullets || '* No changes since previous release');
+            core.setOutput('release_notes', data.body || '* No changes since previous release');
 
       - name: Prepend new section to CHANGELOG.md
         uses: actions/github-script@v7
         env:
           NEXT: ${{ steps.bump.outputs.next }}
-          BULLETS: ${{ steps.notes.outputs.bullets }}
+          RELEASE_NOTES: ${{ steps.notes.outputs.release_notes }}
         with:
           script: |
             const fs = require('fs');
             const version = process.env.NEXT;
             const date = new Date().toISOString().slice(0, 10);
-            const bullets = process.env.BULLETS.trim();
-            const entry = `## [${version}] - ${date}\n\n${bullets}\n\n`;
+            const releaseNotes = process.env.RELEASE_NOTES.trim();
+            const entry = `## [${version}] - ${date}\n\n${releaseNotes}\n\n`;
             const original = fs.readFileSync('CHANGELOG.md', 'utf8');
             fs.writeFileSync('CHANGELOG.md', entry + original);
 
-      - name: Commit and push release branch
+      - name: Commit, push, open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -174,11 +172,18 @@ jobs:
           git add package.json package-lock.json src/config/version.ts manifest.json server.json CHANGELOG.md
           git commit -m "Release ${{ steps.bump.outputs.tag }}"
           git push -u origin "${{ steps.bump.outputs.branch }}"
+          gh pr create \
+            --base main \
+            --head "${{ steps.bump.outputs.branch }}" \
+            --title "Release ${{ steps.bump.outputs.tag }}" \
+            --body "## Automated \`${{ inputs.bump_type }}\` bump from v${{ steps.bump.outputs.current }} to v${{ steps.bump.outputs.next }}
+
+          ${{ steps.notes.outputs.release_notes }}"
 
       - name: Create draft GitHub release
         uses: actions/github-script@v7
         env:
-          BULLETS: ${{ steps.notes.outputs.bullets }}
+          RELEASE_NOTES: ${{ steps.notes.outputs.release_notes }}
         with:
           script: |
             const tag = '${{ steps.bump.outputs.tag }}';
@@ -188,7 +193,7 @@ jobs:
               tag_name: tag,
               target_commitish: '${{ steps.bump.outputs.branch }}',
               name: tag,
-              body: process.env.BULLETS,
+              body: process.env.RELEASE_NOTES,
               draft: true,
               prerelease: false,
             });

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -141,7 +141,7 @@ jobs:
               ...(previousTag ? { previous_tag_name: previousTag } : {}),
             });
 
-            core.setOutput('raw_notes', data.body);
+            core.info('raw_notes', data.body);
 
             // Keep only the PR bullet lines; drop the "## What's Changed" header
             // and the "**Full Changelog**" footer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-## [Unreleased]
-
 ## [0.4.1] - 2026-06-08
 
 * Add `mcpName` and `server.json` for publishing to the official MCP Registry as `io.mailtrap/mcp`.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,7 @@
+import MCP_SERVER_VERSION from "./version";
+
 export default {
   MCP_SERVER_NAME: "mailtrap-mcp-server",
-  MCP_SERVER_VERSION: "0.4.1",
+  MCP_SERVER_VERSION,
   USER_AGENT: "mailtrap-mcp (https://github.com/mailtrap/mailtrap-mcp)",
 };

--- a/src/config/version.ts
+++ b/src/config/version.ts
@@ -1,0 +1,1 @@
+export default "0.4.1";


### PR DESCRIPTION
## Motivation

Automate releases

## Changes

- Implement draft-release workflow

## How to test

- [ ] Visit Github actions
- [ ] Trigger draft-release workflow
- [ ] Assert new release is created in draft state
- [ ] Assert release PR is created


[Example run](https://github.com/mailtrap/mailtrap-mcp/actions/runs/28079070667/job/83129608574)
<img width="2546" height="1158" alt="image" src="https://github.com/user-attachments/assets/df440abe-a37a-4fe3-b9d0-5b18dbefe1d2" />
<img width="1810" height="1462" alt="image" src="https://github.com/user-attachments/assets/234a935f-e545-4404-b7c2-7a9e086e583d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated release drafting with version bumping, changelog generation, and draft release creation.
  * Updated the app to version **0.4.1** across surfaced version information.

* **Chores**
  * Cleaned up the changelog format by removing the unused “Unreleased” header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->