### PR TITLE
Fix draft-release workflow

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -191,7 +191,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag_name: tag,
-              target_commitish: '${{ steps.bump.outputs.branch }}',
+              target_commitish: 'main',
               name: tag,
               body: process.env.RELEASE_NOTES,
               draft: true,


### PR DESCRIPTION
## Motivation

Fix draft-release workflow to create Github Actions release from `main` branch as release-branch gets auto-deleted after release PR is merged


## Changes

- Use proper `target_commttish `

## How to test

- [ ] Trigger draft release
- [ ] Review and merge PR
- [ ] Trigger publish release