### PR TITLE
MT-22678: Add search arg to list_contact_lists tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,7 +733,7 @@ List all contact lists for the account.
 
 **Parameters:**
 
-- No parameters required
+- `search` (optional): Filter contact lists by name (case-insensitive prefix match), e.g. `news`
 
 ### get-contact-list
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ Before using this MCP server, you need to:
 
 [![Install with Node in VS Code](https://img.shields.io/badge/VS_Code-Node-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=mailtrap&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22mcp-mailtrap%22%5D%2C%22env%22%3A%7B%22MAILTRAP_API_TOKEN%22%3A%22%24%7Binput%3AmailtrapApiToken%7D%22%2C%22DEFAULT_FROM_EMAIL%22%3A%22%24%7Binput%3AsenderEmail%7D%22%2C%22MAILTRAP_ACCOUNT_ID%22%3A%22%24%7Binput%3AmailtrapAccountId%7D%22%2C%22MAILTRAP_TEST_INBOX_ID%22%3A%22%24%7Binput%3AmailtrapTestInboxId%7D%22%7D%7D&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22mailtrapApiToken%22%2C%22description%22%3A%22Mailtrap+API+Token%22%2C%22password%22%3Atrue%7D%2C%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22senderEmail%22%2C%22description%22%3A%22Sender+Email+Address%22%7D%2C%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22mailtrapAccountId%22%2C%22description%22%3A%22Mailtrap+Account+ID%22%7D%2C%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22mailtrapTestInboxId%22%2C%22description%22%3A%22Mailtrap+Test+Inbox+ID+%28optional%29%22%7D%5D)
 
-
-
 ### Smithery CLI
 
 [Smithery](https://github.com/smithery-ai/cli) is a registry installer and manager for MCP servers that works with all AI clients.
@@ -45,8 +43,6 @@ npx @smithery/cli install mailtrap
 ```
 
 > Smithery automatically handles client configuration and provides an interactive setup process. It's the easiest way to get started with MCP servers locally.
-
-
 
 ## Setup
 
@@ -111,7 +107,6 @@ If you are using `asdf` for managing Node.js you must use absolute path to execu
 **Windows**: `%USERPROFILE%\.cursor\mcp.json`
 
 ### VS Code
-
 
 #### Manually changing config
 
@@ -389,7 +384,6 @@ Shows detailed information and content of a specific email message from your Mai
 
 > [!NOTE]
 > Use `get-sandbox-messages` first to get the list of messages and their IDs, then use this tool to view the full content of a specific message.
-
 
 ### get-sandbox-project
 
@@ -733,7 +727,7 @@ List all contact lists for the account.
 
 **Parameters:**
 
-- `search` (optional): Filter contact lists by name (case-insensitive prefix match), e.g. `news`
+- `search` (optional): Filter contact lists by name (case-insensitive match), e.g. `news`
 
 ### get-contact-list
 
@@ -1067,7 +1061,7 @@ Both require the bundle to be built first:
 npm run build
 ```
 
-and `MAILTRAP_API_TOKEN` + `MAILTRAP_ACCOUNT_ID` exported in your shell (the `mcp:cli` script forwards both to the spawned server). 
+and `MAILTRAP_API_TOKEN` + `MAILTRAP_ACCOUNT_ID` exported in your shell (the `mcp:cli` script forwards both to the spawned server).
 
 #### Browser UI
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.18.2",
         "dotenv": "^16.4.7",
         "mailsplit": "^5.4.6",
-        "mailtrap": "^4.6.0",
+        "mailtrap": "^4.7.0",
         "zod": "^3.24.2"
       },
       "bin": {
@@ -7656,9 +7656,9 @@
       }
     },
     "node_modules/mailtrap": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/mailtrap/-/mailtrap-4.6.0.tgz",
-      "integrity": "sha512-H9gJ7J5aKTI4eyoJ+Y66NmDEzyxZTiZ+A7OAIeM5xzsapw2IJH1+9RqDe+1R93W2RkFUo5SaXZWlGjXTWUgU4Q==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/mailtrap/-/mailtrap-4.7.0.tgz",
+      "integrity": "sha512-CGQ9ip0riPoymwRYGmBB+WGR+ogkuHESuZtoC/+ii8cpuiGSXzLYJdQK6vFuoNUEJEYW2Ai9szErZ5lPwzK4ZQ==",
       "license": "MIT",
       "dependencies": {
         "axios": ">=0.27",
@@ -7670,7 +7670,7 @@
       },
       "peerDependencies": {
         "@types/nodemailer": "^6.4.9",
-        "nodemailer": "^8.0.5"
+        "nodemailer": "^9.0.1"
       },
       "peerDependenciesMeta": {
         "@types/nodemailer": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@modelcontextprotocol/sdk": "^1.18.2",
     "dotenv": "^16.4.7",
     "mailsplit": "^5.4.6",
-    "mailtrap": "^4.6.0",
+    "mailtrap": "^4.7.0",
     "zod": "^3.24.2"
   },
   "overrides": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -769,7 +769,7 @@ const tools = [
   {
     name: "list-contact-lists",
     description:
-      "List all contact lists for the account. Optionally filter by name with `search` (case-insensitive prefix match).",
+      "List all contact lists for the account. Optionally filter by name with `search` (case-insensitive match).",
     inputSchema: listContactListsSchema,
     handler: listContactLists,
     annotations: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -768,7 +768,8 @@ const tools = [
   },
   {
     name: "list-contact-lists",
-    description: "List all contact lists for the account.",
+    description:
+      "List all contact lists for the account. Optionally filter by name with `search` (case-insensitive prefix match).",
     inputSchema: listContactListsSchema,
     handler: listContactLists,
     annotations: {

--- a/src/tools/contactLists/__tests__/listContactLists.test.ts
+++ b/src/tools/contactLists/__tests__/listContactLists.test.ts
@@ -23,19 +23,49 @@ describe("listContactLists", () => {
       { id: 2, name: "Onboarding" },
     ]);
 
-    const result = await listContactLists();
+    const result = await listContactLists({});
 
     expect(requireClient).toHaveBeenCalledWith("contact lists");
-    expect(mockClient.contactLists.getList).toHaveBeenCalledWith();
+    expect(mockClient.contactLists.getList).toHaveBeenCalledWith(undefined);
     expect(result.content[0].text).toContain('"id": 1');
     expect(result.content[0].text).toContain('"name": "Newsletter"');
     expect(result.isError).toBeUndefined();
   });
 
+  it("passes the search filter to the client when provided", async () => {
+    mockClient.contactLists.getList.mockResolvedValue([
+      { id: 1, name: "Newsletter" },
+    ]);
+
+    const result = await listContactLists({ search: "news" });
+
+    expect(mockClient.contactLists.getList).toHaveBeenCalledWith({
+      search: "news",
+    });
+    expect(result.content[0].text).toContain('"name": "Newsletter"');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("calls the client without options when search is omitted", async () => {
+    mockClient.contactLists.getList.mockResolvedValue([]);
+
+    await listContactLists(undefined);
+
+    expect(mockClient.contactLists.getList).toHaveBeenCalledWith(undefined);
+  });
+
+  it("rejects invalid input", async () => {
+    const result = await listContactLists({ search: 123 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Invalid input");
+    expect(mockClient.contactLists.getList).not.toHaveBeenCalled();
+  });
+
   it("returns the empty message when no lists exist", async () => {
     mockClient.contactLists.getList.mockResolvedValue([]);
 
-    const result = await listContactLists();
+    const result = await listContactLists({});
 
     expect(result.content[0].text).toBe(
       "No contact lists in your Mailtrap account."
@@ -45,7 +75,7 @@ describe("listContactLists", () => {
   it("handles a null response", async () => {
     mockClient.contactLists.getList.mockResolvedValue(null);
 
-    const result = await listContactLists();
+    const result = await listContactLists({});
 
     expect(result.content[0].text).toBe(
       "No contact lists in your Mailtrap account."
@@ -55,7 +85,7 @@ describe("listContactLists", () => {
   it("surfaces API errors", async () => {
     mockClient.contactLists.getList.mockRejectedValue(new Error("boom"));
 
-    const result = await listContactLists();
+    const result = await listContactLists({});
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toBe("Failed to list contact lists: boom");

--- a/src/tools/contactLists/listContactLists.ts
+++ b/src/tools/contactLists/listContactLists.ts
@@ -5,15 +5,28 @@ import {
   buildSuccessResponse,
   ToolResponse,
 } from "../utils/responses";
+import { listContactListsZod } from "./schemas/listContactLists";
 
-async function listContactLists(): Promise<ToolResponse> {
+async function listContactLists(raw: unknown): Promise<ToolResponse> {
   try {
+    const parsed = listContactListsZod.safeParse(raw ?? {});
+    if (!parsed.success) {
+      const msg = parsed.error.errors
+        .map((e) => `${e.path.join(".")}: ${e.message}`)
+        .join("; ");
+      return {
+        content: [{ type: "text", text: `Invalid input: ${msg}` }],
+        isError: true,
+      };
+    }
+
+    const { search } = parsed.data;
+
     const mailtrap = requireClient("contact lists");
 
-    const lists = (await mailtrap.contactLists.getList()) as
-      | ContactList[]
-      | null
-      | undefined;
+    const lists = (await mailtrap.contactLists.getList(
+      search ? { search } : undefined
+    )) as ContactList[] | null | undefined;
 
     if (!lists || lists.length === 0) {
       return buildSuccessResponse("No contact lists in your Mailtrap account.");

--- a/src/tools/contactLists/schemas/listContactLists.ts
+++ b/src/tools/contactLists/schemas/listContactLists.ts
@@ -6,7 +6,7 @@ const listContactListsSchema = {
     search: {
       type: "string",
       description:
-        'Filter contact lists by name (case-insensitive prefix match), e.g. "news".',
+        'Filter contact lists by name (case-insensitive match), e.g. "news".',
     },
   },
   required: [],

--- a/src/tools/contactLists/schemas/listContactLists.ts
+++ b/src/tools/contactLists/schemas/listContactLists.ts
@@ -1,7 +1,22 @@
+import { z } from "zod";
+
 const listContactListsSchema = {
   type: "object",
-  properties: {},
+  properties: {
+    search: {
+      type: "string",
+      description:
+        'Filter contact lists by name (case-insensitive prefix match), e.g. "news".',
+    },
+  },
+  required: [],
   additionalProperties: false,
 };
+
+export const listContactListsZod = z
+  .object({
+    search: z.string().optional(),
+  })
+  .strict();
 
 export default listContactListsSchema;


### PR DESCRIPTION
## Motivation

MT-22678 exposes the contact-list name `search` query param (added to `GET /api/contacts/lists` in MT-22147) across all Mailtrap SDKs. This PR is the MCP piece: it surfaces the optional `search` filter on the `list-contact-lists` tool so MCP clients can filter contact lists by name (case-insensitive match).

## Changes

- `src/tools/contactLists/schemas/listContactLists.ts`: add an optional `search` string to the JSON Schema `properties` and export a matching `listContactListsZod` schema (mirrors `schemas/listEmailLogs.ts`).
- `src/tools/contactLists/listContactLists.ts`: handler now accepts `raw: unknown`, validates it with the Zod schema (returns the standard `Invalid input` error on failure), and passes `{ search }` to `mailtrap.contactLists.getList(...)` only when provided.
- `src/server.ts`: tool description notes the optional `search` filter so the LLM can discover it. Registration already passed the schema as `inputSchema`.
- `README.md`: document the optional `search` arg on the "List all contact lists" tool entry.
- Tests: extend `src/tools/contactLists/__tests__/listContactLists.test.ts` to assert `getList` is called with `{ search: "news" }` when provided, with `undefined` when omitted, and that invalid input is rejected.
- `package.json`: bump `mailtrap` to `^4.7.0`.

## How to test

- [ ] `yarn jest contactLists` — all contact-list tool tests pass (search arg threaded through, no-arg case unchanged).
- [ ] With a real `MAILTRAP_API_TOKEN` + `MAILTRAP_ACCOUNT_ID`, invoke the `list-contact-lists` tool with `{ "search": "news" }` and confirm results are filtered by name prefix; invoke with no args and confirm all lists return.
