### PR TITLE
Fix send-email recipients lost when MCP clients strip oneOf from schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,10 +206,10 @@ Sends a transactional email through Mailtrap. Supports two mutually exclusive mo
 
 **Parameters:**
 
-- `from` (optional): Sender as an email string or `{ email, name? }`. If not provided, `DEFAULT_FROM_EMAIL` is used.
-- `to` (optional): Recipient(s) — a single email/`{ email, name? }` or an array. Optional if `cc` or `bcc` is provided; at least one of `to` / `cc` / `bcc` must contain a recipient.
-- `cc` (optional): Array of CC recipients (email strings or `{ email, name? }` each).
-- `bcc` (optional): Array of BCC recipients (email strings or `{ email, name? }` each).
+- `from` (optional): Sender as `{ email, name? }` (a bare email string is also accepted at runtime). If not provided, `DEFAULT_FROM_EMAIL` is used.
+- `to` (optional): Array of recipients as `{ email, name? }` objects (bare email strings, or a single non-array address, are also accepted at runtime). Optional if `cc` or `bcc` is provided; at least one of `to` / `cc` / `bcc` must contain a recipient.
+- `cc` (optional): Array of CC recipients as `{ email, name? }` objects (bare email strings also accepted at runtime).
+- `bcc` (optional): Array of BCC recipients as `{ email, name? }` objects (bare email strings also accepted at runtime).
 - `subject` (conditional): Email subject line. Required for inline sends; must be omitted when `template_uuid` is set.
 - `text` (conditional): Email body text. Required (alongside or instead of `html`) for inline sends; must be omitted when `template_uuid` is set.
 - `html` (conditional): HTML version of the email body. Required (alongside or instead of `text`) for inline sends; must be omitted when `template_uuid` is set.
@@ -224,14 +224,14 @@ Sends a batch of transactional emails in one Mailtrap API call (default sending 
 **Parameters:**
 
 - `base` (optional): Object with fields shared across the batch.
-  - `from` (optional): Sender as an email string or `{ email, name? }`. Falls back to `DEFAULT_FROM_EMAIL`.
+  - `from` (optional): Sender as `{ email, name? }` (a bare email string is also accepted at runtime). Falls back to `DEFAULT_FROM_EMAIL`.
   - `reply_to` (optional): Reply-to address.
   - `subject` / `text` / `html` / `category` (optional, inline mode): Default content for every request.
   - `template_uuid` / `template_variables` (optional, template mode): Default template + variables. Mutually exclusive with the inline fields.
   - `custom_variables` (optional): Default custom variables (string-valued).
   - `headers` (optional): Default custom headers.
 - `requests` (required): Non-empty array of per-recipient messages. Each entry has:
-  - `to` (optional): Recipient(s) — string, `{ email, name? }`, or an array. Optional if `cc` or `bcc` is provided; at least one of `to` / `cc` / `bcc` must contain a recipient.
+  - `to` (optional): Array of recipients as `{ email, name? }` objects (bare email strings, or a single non-array address, are also accepted at runtime). Optional if `cc` or `bcc` is provided; at least one of `to` / `cc` / `bcc` must contain a recipient.
   - `cc`, `bcc`, `reply_to` (optional).
   - Inline (`subject`/`text`/`html`/`category`) or template (`template_uuid`/`template_variables`) overrides; any field omitted falls back to the matching `base` value.
   - `custom_variables`, `headers` (optional).
@@ -347,10 +347,10 @@ Sends an email to your Mailtrap test inbox for development and testing purposes.
 **Parameters:**
 
 - `test_inbox_id` (optional): Mailtrap test inbox ID. Required unless `MAILTRAP_TEST_INBOX_ID` is set; pass per call to target a specific inbox.
-- `from` (optional): Sender as an email string or `{ email, name? }`. If not provided, `DEFAULT_FROM_EMAIL` is used.
-- `to` (optional): Recipients as a comma-separated string, or an array of email strings / `{ email, name? }` objects. Optional if `cc` or `bcc` is provided; at least one of `to` / `cc` / `bcc` must contain a recipient.
-- `cc` (optional): Array of CC recipients (email strings or `{ email, name? }` each).
-- `bcc` (optional): Array of BCC recipients (email strings or `{ email, name? }` each).
+- `from` (optional): Sender as `{ email, name? }` (a bare email string is also accepted at runtime). If not provided, `DEFAULT_FROM_EMAIL` is used.
+- `to` (optional): Array of recipients as `{ email, name? }` objects (bare email strings in the array, or a comma-separated string of plain emails, are also accepted at runtime). Optional if `cc` or `bcc` is provided; at least one of `to` / `cc` / `bcc` must contain a recipient.
+- `cc` (optional): Array of CC recipients as `{ email, name? }` objects (bare email strings also accepted at runtime).
+- `bcc` (optional): Array of BCC recipients as `{ email, name? }` objects (bare email strings also accepted at runtime).
 - `subject` (conditional): Email subject line. Required for inline sends; must be omitted when `template_uuid` is set.
 - `text` (conditional): Email body text. Required (alongside or instead of `html`) for inline sends; must be omitted when `template_uuid` is set.
 - `html` (conditional): HTML version of the email body. Required (alongside or instead of `text`) for inline sends; must be omitted when `template_uuid` is set.

--- a/src/tools/sandbox/__tests__/sendSandboxEmail.test.ts
+++ b/src/tools/sandbox/__tests__/sendSandboxEmail.test.ts
@@ -606,4 +606,34 @@ describe("sendSandboxEmail", () => {
       consoleErrorSpy.mockRestore();
     });
   });
+
+  describe("JSON-stringified recipients", () => {
+    it("should accept 'to' as a JSON-stringified array of objects", async () => {
+      const result = await sendSandboxEmail({
+        ...mockEmailData,
+        to: '[{"email": "john@example.com", "name": "John Doe"}]',
+      });
+
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ email: "john@example.com", name: "John Doe" }],
+        })
+      );
+      expect(result.isError).toBeUndefined();
+    });
+
+    it("should accept 'to' as a JSON-stringified array of strings", async () => {
+      const result = await sendSandboxEmail({
+        ...mockEmailData,
+        to: '["john@example.com"]',
+      });
+
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ email: "john@example.com" }],
+        })
+      );
+      expect(result.isError).toBeUndefined();
+    });
+  });
 });

--- a/src/tools/sandbox/schemas/sendSandboxEmail.ts
+++ b/src/tools/sandbox/schemas/sendSandboxEmail.ts
@@ -1,4 +1,9 @@
-import mailtrapAddressParamSchema from "../../schemas/mailtrapAddressParam";
+import {
+  mailtrapAddressListParamSchema,
+  mailtrapBccParamSchema,
+  mailtrapCcParamSchema,
+  mailtrapFromParamSchema,
+} from "../../schemas/mailtrapAddressParam";
 
 const sendSandboxEmailSchema = {
   type: "object",
@@ -8,45 +13,19 @@ const sendSandboxEmailSchema = {
       description:
         "Mailtrap test inbox ID. Optional if MAILTRAP_TEST_INBOX_ID env var is set. Use to target a specific inbox.",
     },
-    from: {
-      ...mailtrapAddressParamSchema,
-      description:
-        "Sender as an email string or `{ email, name? }`. Omit if DEFAULT_FROM_EMAIL is set.",
-    },
+    from: mailtrapFromParamSchema,
     to: {
-      oneOf: [
-        {
-          type: "string",
-          minLength: 1,
-          description:
-            "Comma-separated email addresses (plain emails only; use array form for display names).",
-        },
-        {
-          type: "array",
-          minItems: 1,
-          items: mailtrapAddressParamSchema,
-          description:
-            "Array of recipients as email strings or `{ email, name? }` objects.",
-        },
-      ],
+      ...mailtrapAddressListParamSchema,
       description:
-        "Recipients: comma-separated string, or an array of addresses with optional display names. Optional if `cc` or `bcc` is provided; at least one of `to`/`cc`/`bcc` must contain a recipient.",
+        "Recipients as an array of `{ email, name? }` objects (bare email strings as items, or a comma-separated string of plain emails, are also accepted). Optional if `cc` or `bcc` is provided; at least one of `to`/`cc`/`bcc` must contain a recipient.",
     },
     subject: {
       type: "string",
       description:
         "Email subject line. Required for inline (text/html) sends; must be omitted when `template_uuid` is set.",
     },
-    cc: {
-      type: "array",
-      items: mailtrapAddressParamSchema,
-      description: "Optional CC recipients (email or `{ email, name? }` each)",
-    },
-    bcc: {
-      type: "array",
-      items: mailtrapAddressParamSchema,
-      description: "Optional BCC recipients (email or `{ email, name? }` each)",
-    },
+    cc: mailtrapCcParamSchema,
+    bcc: mailtrapBccParamSchema,
     category: {
       type: "string",
       description:

--- a/src/tools/sandbox/sendSandboxEmail.ts
+++ b/src/tools/sandbox/sendSandboxEmail.ts
@@ -67,8 +67,8 @@ async function sendSandboxEmail({
     const sandboxClient = getSandboxClient(inboxId);
 
     const toAddresses = to !== undefined ? parseSandboxTo(to) : [];
-    const ccAddresses = cc && cc.length > 0 ? normalizeAddressList(cc) : [];
-    const bccAddresses = bcc && bcc.length > 0 ? normalizeAddressList(bcc) : [];
+    const ccAddresses = cc ? normalizeAddressList(cc) : [];
+    const bccAddresses = bcc ? normalizeAddressList(bcc) : [];
 
     if (toAddresses.length + ccAddresses.length + bccAddresses.length === 0) {
       throw new Error(

--- a/src/tools/schemas/mailtrapAddressParam.ts
+++ b/src/tools/schemas/mailtrapAddressParam.ts
@@ -1,31 +1,58 @@
 /**
- * JSON Schema fragment: email string or `{ email, name? }` for Mailtrap Address fields.
+ * JSON Schema fragments for Mailtrap address fields.
+ *
+ * Deliberately combinator-free: some MCP clients (e.g. Claude Desktop) strip
+ * `oneOf`/`anyOf` from property schemas, leaving an empty `{}` schema and
+ * causing arguments to arrive corrupted (JSON-stringified). Handlers still
+ * accept a bare email string at runtime via the address normalizers.
  */
 const mailtrapAddressParamSchema = {
-  oneOf: [
-    {
+  type: "object",
+  description:
+    "Address with optional display name (a bare email string is also accepted)",
+  properties: {
+    email: {
       type: "string",
       format: "email",
       description: "Email address",
     },
-    {
-      type: "object",
-      description: "Address with optional display name",
-      properties: {
-        email: {
-          type: "string",
-          format: "email",
-          description: "Email address",
-        },
-        name: {
-          type: "string",
-          description: "Display name for this address",
-        },
-      },
-      required: ["email"],
-      additionalProperties: false,
+    name: {
+      type: "string",
+      description: "Display name for this address",
     },
-  ],
+  },
+  required: ["email"],
+  additionalProperties: false,
 };
+
+/**
+ * Shared fragment for recipient-list properties (`to` in the send tools):
+ * a non-empty array of address objects. Spread and override `description`
+ * where a tool accepts extra forms (e.g. the sandbox comma-separated string).
+ */
+export const mailtrapAddressListParamSchema = {
+  type: "array",
+  minItems: 1,
+  items: mailtrapAddressParamSchema,
+  description:
+    "Recipients as an array of `{ email, name? }` objects (bare email strings are also accepted as items). Optional if `cc` or `bcc` is provided; at least one of `to`/`cc`/`bcc` must contain a recipient.",
+};
+
+/** Shared fragment for `from` properties in the send tools. */
+export const mailtrapFromParamSchema = {
+  ...mailtrapAddressParamSchema,
+  description:
+    "Sender as `{ email, name? }` (a bare email string is also accepted). Omit if `DEFAULT_FROM_EMAIL` is set.",
+};
+
+const optionalRecipientListSchema = (kind: "CC" | "BCC") => ({
+  type: "array",
+  items: mailtrapAddressParamSchema,
+  description: `Optional ${kind} recipients as \`{ email, name? }\` objects (bare email strings also accepted)`,
+});
+
+/** Shared fragments for `cc`/`bcc` properties in the send tools. */
+export const mailtrapCcParamSchema = optionalRecipientListSchema("CC");
+export const mailtrapBccParamSchema = optionalRecipientListSchema("BCC");
 
 export default mailtrapAddressParamSchema;

--- a/src/tools/sendEmail/__tests__/sendEmail.test.ts
+++ b/src/tools/sendEmail/__tests__/sendEmail.test.ts
@@ -572,4 +572,48 @@ describe("sendEmail", () => {
       });
     });
   });
+
+  describe("JSON-stringified recipients", () => {
+    it("should accept 'to' as a JSON-stringified array of objects", async () => {
+      const result = await sendEmail({
+        ...mockEmailData,
+        to: '[{"email": "john@example.com", "name": "John Doe"}]',
+      });
+
+      expect(mockClient.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ email: "john@example.com", name: "John Doe" }],
+        })
+      );
+      expect(result.isError).toBeUndefined();
+    });
+
+    it("should accept 'to' as a JSON-stringified array of strings", async () => {
+      const result = await sendEmail({
+        ...mockEmailData,
+        to: '["john@example.com"]',
+      });
+
+      expect(mockClient.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: [{ email: "john@example.com" }],
+        })
+      );
+      expect(result.isError).toBeUndefined();
+    });
+
+    it("should accept 'from' as a JSON-stringified object", async () => {
+      const result = await sendEmail({
+        ...mockEmailData,
+        from: '{"email": "sender@example.com", "name": "Sender"}',
+      });
+
+      expect(mockClient.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: { email: "sender@example.com", name: "Sender" },
+        })
+      );
+      expect(result.isError).toBeUndefined();
+    });
+  });
 });

--- a/src/tools/sendEmail/buildBatchPayload.ts
+++ b/src/tools/sendEmail/buildBatchPayload.ts
@@ -100,7 +100,8 @@ function buildBatchPayload({
   const fromAddress = buildFromAddress(base?.from, DEFAULT_FROM_EMAIL);
 
   const sdkBase: Record<string, unknown> = { from: fromAddress };
-  if (base?.reply_to) sdkBase.reply_to = toMailtrapAddress(base.reply_to);
+  if (base?.reply_to)
+    sdkBase.reply_to = toMailtrapAddress(base.reply_to, "base 'reply_to'");
   if (base?.subject !== undefined) sdkBase.subject = base.subject;
   if (base?.text !== undefined) sdkBase.text = base.text;
   if (base?.html !== undefined) sdkBase.html = base.html;
@@ -116,10 +117,8 @@ function buildBatchPayload({
   const sdkRequests = requests.map((req, i) => {
     const toAddresses =
       req.to !== undefined ? normalizeToRecipients(req.to) : [];
-    const ccAddresses =
-      req.cc && req.cc.length > 0 ? normalizeAddressList(req.cc) : [];
-    const bccAddresses =
-      req.bcc && req.bcc.length > 0 ? normalizeAddressList(req.bcc) : [];
+    const ccAddresses = req.cc ? normalizeAddressList(req.cc) : [];
+    const bccAddresses = req.bcc ? normalizeAddressList(req.bcc) : [];
 
     if (toAddresses.length + ccAddresses.length + bccAddresses.length === 0) {
       throw new Error(
@@ -132,7 +131,10 @@ function buildBatchPayload({
     };
     if (ccAddresses.length > 0) r.cc = ccAddresses;
     if (bccAddresses.length > 0) r.bcc = bccAddresses;
-    if (req.reply_to) r.reply_to = [toMailtrapAddress(req.reply_to)];
+    if (req.reply_to)
+      r.reply_to = [
+        toMailtrapAddress(req.reply_to, `requests[${i}] 'reply_to'`),
+      ];
     if (req.subject !== undefined) r.subject = req.subject;
     if (req.text !== undefined) r.text = req.text;
     if (req.html !== undefined) r.html = req.html;

--- a/src/tools/sendEmail/schema.ts
+++ b/src/tools/sendEmail/schema.ts
@@ -1,40 +1,22 @@
-import mailtrapAddressParamSchema from "../schemas/mailtrapAddressParam";
+import {
+  mailtrapAddressListParamSchema,
+  mailtrapBccParamSchema,
+  mailtrapCcParamSchema,
+  mailtrapFromParamSchema,
+} from "../schemas/mailtrapAddressParam";
 
 const sendEmailSchema = {
   type: "object",
   properties: {
-    from: {
-      ...mailtrapAddressParamSchema,
-      description:
-        "Sender as an email string or `{ email, name? }` for a display name. Omit if DEFAULT_FROM_EMAIL is set.",
-    },
-    to: {
-      oneOf: [
-        mailtrapAddressParamSchema,
-        {
-          type: "array",
-          minItems: 1,
-          items: mailtrapAddressParamSchema,
-        },
-      ],
-      description:
-        "Recipient(s): one address (string or `{ email, name? }`) or a non-empty array of those. Optional if `cc` or `bcc` is provided; at least one of `to`/`cc`/`bcc` must contain a recipient.",
-    },
+    from: mailtrapFromParamSchema,
+    to: mailtrapAddressListParamSchema,
     subject: {
       type: "string",
       description:
         "Email subject line. Required for inline (text/html) sends; must be omitted when `template_uuid` is set.",
     },
-    cc: {
-      type: "array",
-      items: mailtrapAddressParamSchema,
-      description: "Optional CC recipients (email or `{ email, name? }` each)",
-    },
-    bcc: {
-      type: "array",
-      items: mailtrapAddressParamSchema,
-      description: "Optional BCC recipients (email or `{ email, name? }` each)",
-    },
+    cc: mailtrapCcParamSchema,
+    bcc: mailtrapBccParamSchema,
     category: {
       type: "string",
       description:

--- a/src/tools/sendEmail/schemas/batchSendStreamEmail.ts
+++ b/src/tools/sendEmail/schemas/batchSendStreamEmail.ts
@@ -1,15 +1,9 @@
-import mailtrapAddressParamSchema from "../../schemas/mailtrapAddressParam";
-
-const addressArrayOrSingle = {
-  oneOf: [
-    mailtrapAddressParamSchema,
-    {
-      type: "array",
-      minItems: 1,
-      items: mailtrapAddressParamSchema,
-    },
-  ],
-};
+import mailtrapAddressParamSchema, {
+  mailtrapAddressListParamSchema,
+  mailtrapBccParamSchema,
+  mailtrapCcParamSchema,
+  mailtrapFromParamSchema,
+} from "../../schemas/mailtrapAddressParam";
 
 const inlineOrTemplateProps = {
   subject: {
@@ -61,14 +55,11 @@ const batchSendStreamEmailSchema = {
       description:
         "Shared fields applied to every request in the batch. Each request can override individual fields.",
       properties: {
-        from: {
-          ...mailtrapAddressParamSchema,
-          description:
-            "Sender as an email string or `{ email, name? }`. Omit if `DEFAULT_FROM_EMAIL` is set.",
-        },
+        from: mailtrapFromParamSchema,
         reply_to: {
           ...mailtrapAddressParamSchema,
-          description: "Optional reply-to address.",
+          description:
+            "Optional reply-to address as `{ email, name? }` (a bare email string is also accepted).",
         },
         ...inlineOrTemplateProps,
       },
@@ -82,24 +73,13 @@ const batchSendStreamEmailSchema = {
       items: {
         type: "object",
         properties: {
-          to: {
-            ...addressArrayOrSingle,
-            description:
-              "Recipient(s): one address (string or `{ email, name? }`) or a non-empty array. Optional if `cc` or `bcc` is provided; at least one of `to`/`cc`/`bcc` must contain a recipient.",
-          },
-          cc: {
-            type: "array",
-            items: mailtrapAddressParamSchema,
-            description: "Optional CC recipients.",
-          },
-          bcc: {
-            type: "array",
-            items: mailtrapAddressParamSchema,
-            description: "Optional BCC recipients.",
-          },
+          to: mailtrapAddressListParamSchema,
+          cc: mailtrapCcParamSchema,
+          bcc: mailtrapBccParamSchema,
           reply_to: {
             ...mailtrapAddressParamSchema,
-            description: "Optional reply-to override for this request.",
+            description:
+              "Optional reply-to override for this request as `{ email, name? }` (a bare email string is also accepted).",
           },
           ...inlineOrTemplateProps,
         },

--- a/src/tools/sendEmail/sendEmail.ts
+++ b/src/tools/sendEmail/sendEmail.ts
@@ -57,8 +57,8 @@ async function sendEmail({
     const fromAddress = buildFromAddress(from, DEFAULT_FROM_EMAIL);
 
     const toAddresses = to !== undefined ? normalizeToRecipients(to) : [];
-    const ccAddresses = cc && cc.length > 0 ? normalizeAddressList(cc) : [];
-    const bccAddresses = bcc && bcc.length > 0 ? normalizeAddressList(bcc) : [];
+    const ccAddresses = cc ? normalizeAddressList(cc) : [];
+    const bccAddresses = bcc ? normalizeAddressList(bcc) : [];
 
     if (toAddresses.length + ccAddresses.length + bccAddresses.length === 0) {
       throw new Error(

--- a/src/utils/__tests__/mailtrapAddresses.test.ts
+++ b/src/utils/__tests__/mailtrapAddresses.test.ts
@@ -1,0 +1,189 @@
+import {
+  buildFromAddress,
+  normalizeAddressList,
+  normalizeToRecipients,
+  parseSandboxTo,
+  toMailtrapAddress,
+} from "../mailtrapAddresses";
+
+describe("toMailtrapAddress", () => {
+  it("wraps a plain email string", () => {
+    expect(toMailtrapAddress(" john@example.com ")).toEqual({
+      email: "john@example.com",
+    });
+  });
+
+  it("keeps email and trimmed name from an object", () => {
+    expect(
+      toMailtrapAddress({ email: "john@example.com", name: " John " })
+    ).toEqual({
+      email: "john@example.com",
+      name: "John",
+    });
+  });
+
+  it("drops an empty name", () => {
+    expect(
+      toMailtrapAddress({ email: "john@example.com", name: "  " })
+    ).toEqual({
+      email: "john@example.com",
+    });
+  });
+
+  it("revives a JSON-stringified object", () => {
+    expect(
+      toMailtrapAddress('{"email": "john@example.com", "name": "John"}')
+    ).toEqual({ email: "john@example.com", name: "John" });
+  });
+
+  it("throws on an address without a usable email", () => {
+    expect(() => toMailtrapAddress("   ")).toThrow("Invalid address");
+    expect(() => toMailtrapAddress({ email: "" })).toThrow("Invalid address");
+  });
+});
+
+describe("buildFromAddress", () => {
+  it("falls back to the default email when from is undefined", () => {
+    expect(buildFromAddress(undefined, "default@example.com")).toEqual({
+      email: "default@example.com",
+    });
+  });
+
+  it("throws when from is undefined and no default is set", () => {
+    expect(() => buildFromAddress(undefined, undefined)).toThrow(
+      "Provide 'from' or set DEFAULT_FROM_EMAIL"
+    );
+  });
+
+  it("normalizes an explicit from address", () => {
+    expect(
+      buildFromAddress(
+        { email: "sender@example.com", name: "Sender" },
+        undefined
+      )
+    ).toEqual({ email: "sender@example.com", name: "Sender" });
+  });
+});
+
+describe("normalizeToRecipients", () => {
+  it("accepts a single email string", () => {
+    expect(normalizeToRecipients("john@example.com")).toEqual([
+      { email: "john@example.com" },
+    ]);
+  });
+
+  it("accepts a single address object", () => {
+    expect(
+      normalizeToRecipients({ email: "john@example.com", name: "John" })
+    ).toEqual([{ email: "john@example.com", name: "John" }]);
+  });
+
+  it("accepts a mixed array of strings and objects", () => {
+    expect(
+      normalizeToRecipients([
+        "a@example.com",
+        { email: "b@example.com", name: "B" },
+      ])
+    ).toEqual([
+      { email: "a@example.com" },
+      { email: "b@example.com", name: "B" },
+    ]);
+  });
+
+  it("drops entries without a usable email", () => {
+    expect(
+      normalizeToRecipients(["  ", { email: "" }, "a@example.com"])
+    ).toEqual([{ email: "a@example.com" }]);
+  });
+
+  // Some MCP clients strip `oneOf` from property schemas and then deliver
+  // array/object arguments as JSON-encoded strings.
+  it("revives a JSON-stringified array of strings", () => {
+    expect(normalizeToRecipients('["john@example.com"]')).toEqual([
+      { email: "john@example.com" },
+    ]);
+  });
+
+  it("revives a JSON-stringified array of objects (pretty-printed)", () => {
+    expect(
+      normalizeToRecipients(
+        '[{"email": "john@example.com", "name": "John Doe"}]'
+      )
+    ).toEqual([{ email: "john@example.com", name: "John Doe" }]);
+  });
+
+  it("revives a JSON-stringified single object", () => {
+    expect(normalizeToRecipients('{"email":"john@example.com"}')).toEqual([
+      { email: "john@example.com" },
+    ]);
+  });
+
+  it("keeps a string that merely looks JSON-ish but does not parse", () => {
+    expect(normalizeToRecipients("[not-json]")).toEqual([
+      { email: "[not-json]" },
+    ]);
+  });
+
+  it("drops nested arrays instead of recursing into them", () => {
+    expect(normalizeToRecipients([["a@example.com"]] as never)).toEqual([]);
+    const depth = 10000;
+    const nested = `${"[".repeat(depth)}"a@example.com"${"]".repeat(depth)}`;
+    expect(normalizeToRecipients(nested)).toEqual([]);
+  });
+});
+
+describe("normalizeAddressList", () => {
+  it("normalizes an array of mixed entries", () => {
+    expect(
+      normalizeAddressList(["a@example.com", { email: "b@example.com" }])
+    ).toEqual([{ email: "a@example.com" }, { email: "b@example.com" }]);
+  });
+
+  it("revives JSON-stringified items inside a real array", () => {
+    expect(
+      normalizeAddressList(['{"email": "a@example.com", "name": "A"}'])
+    ).toEqual([{ email: "a@example.com", name: "A" }]);
+  });
+
+  it("revives the whole list when it arrives JSON-stringified", () => {
+    expect(
+      normalizeAddressList('[{"email": "a@example.com"}, "b@example.com"]')
+    ).toEqual([{ email: "a@example.com" }, { email: "b@example.com" }]);
+  });
+});
+
+describe("parseSandboxTo", () => {
+  it("parses a comma-separated string of plain emails", () => {
+    expect(parseSandboxTo("a@example.com, b@example.com")).toEqual([
+      { email: "a@example.com" },
+      { email: "b@example.com" },
+    ]);
+  });
+
+  it("skips invalid entries in a comma-separated string", () => {
+    expect(parseSandboxTo("a@example.com, not-an-email, ")).toEqual([
+      { email: "a@example.com" },
+    ]);
+  });
+
+  it("normalizes an array of address params", () => {
+    expect(
+      parseSandboxTo([{ email: "a@example.com", name: "A" }, "b@example.com"])
+    ).toEqual([
+      { email: "a@example.com", name: "A" },
+      { email: "b@example.com" },
+    ]);
+  });
+
+  it("revives a JSON-stringified array of objects (pretty-printed)", () => {
+    expect(
+      parseSandboxTo('[{"email": "john@example.com", "name": "John Doe"}]')
+    ).toEqual([{ email: "john@example.com", name: "John Doe" }]);
+  });
+
+  it("revives a JSON-stringified array of strings", () => {
+    expect(parseSandboxTo('["john@example.com"]')).toEqual([
+      { email: "john@example.com" },
+    ]);
+  });
+});

--- a/src/utils/__tests__/mailtrapAddresses.test.ts
+++ b/src/utils/__tests__/mailtrapAddresses.test.ts
@@ -40,6 +40,21 @@ describe("toMailtrapAddress", () => {
     expect(() => toMailtrapAddress("   ")).toThrow("Invalid address");
     expect(() => toMailtrapAddress({ email: "" })).toThrow("Invalid address");
   });
+
+  it("rejects arrays instead of taking the first entry", () => {
+    expect(() =>
+      toMailtrapAddress(["a@example.com", "b@example.com"] as never)
+    ).toThrow("Invalid address");
+    expect(() =>
+      toMailtrapAddress('["a@example.com", "b@example.com"]')
+    ).toThrow("Invalid address");
+  });
+
+  it("names the field in the error message when context is given", () => {
+    expect(() => toMailtrapAddress("   ", "'reply_to'")).toThrow(
+      "Invalid address in 'reply_to'"
+    );
+  });
 });
 
 describe("buildFromAddress", () => {

--- a/src/utils/mailtrapAddresses.ts
+++ b/src/utils/mailtrapAddresses.ts
@@ -66,6 +66,8 @@ function normalizeAddressValue(value: unknown): Address[] {
 }
 
 /**
+ * Normalizes a singular address field (`from`, `reply_to`) into a single
+ * Mailtrap address. Throws on arrays and entries without a usable email.
  * `context` names the field (and, for batch sends, the request) in the error
  * message, e.g. `"'from'"` or `"requests[2] 'reply_to'"`.
  */
@@ -73,7 +75,7 @@ export function toMailtrapAddress(
   input: MailtrapAddressParam,
   context?: string
 ): Address {
-  const [first] = normalizeAddressValue(input);
+  const [first] = normalizeAddressItem(input);
   if (!first) {
     throw new Error(
       `Invalid address${
@@ -84,6 +86,11 @@ export function toMailtrapAddress(
   return first;
 }
 
+/**
+ * Resolves the sender address: normalizes an explicit `from` when given,
+ * otherwise falls back to `defaultEmail` (the `DEFAULT_FROM_EMAIL` env var).
+ * Throws when neither is available.
+ */
 export function buildFromAddress(
   from: MailtrapAddressParam | undefined,
   defaultEmail: string | undefined
@@ -99,12 +106,22 @@ export function buildFromAddress(
   return toMailtrapAddress(from, "'from'");
 }
 
+/**
+ * Normalizes an optional multi-address field (e.g. `cc`, `bcc`) — an array of
+ * entries or a JSON-stringified array — into Mailtrap addresses, dropping
+ * entries without a usable email.
+ */
 export function normalizeAddressList(
   inputs: MailtrapAddressParam[] | string
 ): Address[] {
   return normalizeAddressValue(inputs);
 }
 
+/**
+ * Normalizes the `to` field — a single entry, an array of entries, or a
+ * JSON-stringified form of either — into Mailtrap addresses. Returns an empty
+ * array when no entry has a usable email; callers validate non-emptiness.
+ */
 export function normalizeToRecipients(
   to: MailtrapAddressParam | MailtrapAddressParam[]
 ): Address[] {

--- a/src/utils/mailtrapAddresses.ts
+++ b/src/utils/mailtrapAddresses.ts
@@ -2,16 +2,86 @@ import { Address } from "mailtrap";
 
 import type { MailtrapAddressParam } from "../types/mailtrap";
 
-export function toMailtrapAddress(input: MailtrapAddressParam): Address {
-  if (typeof input === "string") {
-    return { email: input.trim() };
+/**
+ * Some MCP clients (e.g. Claude Desktop) strip `oneOf` unions from property
+ * schemas, after which array/object arguments can arrive as JSON-encoded
+ * strings. If a string value looks like a JSON array/object, parse it back;
+ * otherwise return the value unchanged.
+ */
+function reviveJsonString(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
   }
-  const addr: Address = { email: input.email.trim() };
-  const name = input.name?.trim();
-  if (name) {
-    addr.name = name;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("[") && !trimmed.startsWith("{")) {
+    return value;
   }
-  return addr;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Normalizes a single address entry — an email string, `{ email, name? }`,
+ * or a JSON-stringified form of either. Entries without a usable email are
+ * dropped, as are nested arrays (only one list level is semantically valid).
+ */
+function normalizeAddressItem(item: unknown): Address[] {
+  const revived = reviveJsonString(item);
+  if (typeof revived === "string") {
+    const e = revived.trim();
+    return e.length > 0 ? [{ email: e }] : [];
+  }
+  if (
+    revived !== null &&
+    typeof revived === "object" &&
+    !Array.isArray(revived)
+  ) {
+    const { email, name } = revived as { email?: unknown; name?: unknown };
+    const e = typeof email === "string" ? email.trim() : "";
+    if (e.length === 0) {
+      return [];
+    }
+    const addr: Address = { email: e };
+    const trimmedName = typeof name === "string" ? name.trim() : "";
+    if (trimmedName) {
+      addr.name = trimmedName;
+    }
+    return [addr];
+  }
+  return [];
+}
+
+/**
+ * Normalizes any accepted address input — a single entry, an array of
+ * entries, or a JSON-stringified form of those — into a list of Mailtrap
+ * addresses.
+ */
+function normalizeAddressValue(value: unknown): Address[] {
+  const revived = reviveJsonString(value);
+  const list = Array.isArray(revived) ? revived : [revived];
+  return list.flatMap(normalizeAddressItem);
+}
+
+/**
+ * `context` names the field (and, for batch sends, the request) in the error
+ * message, e.g. `"'from'"` or `"requests[2] 'reply_to'"`.
+ */
+export function toMailtrapAddress(
+  input: MailtrapAddressParam,
+  context?: string
+): Address {
+  const [first] = normalizeAddressValue(input);
+  if (!first) {
+    throw new Error(
+      `Invalid address${
+        context ? ` in ${context}` : ""
+      }: provide an email string or \`{ email, name? }\``
+    );
+  }
+  return first;
 }
 
 export function buildFromAddress(
@@ -26,50 +96,36 @@ export function buildFromAddress(
     }
     return { email: defaultEmail };
   }
-  return toMailtrapAddress(from);
+  return toMailtrapAddress(from, "'from'");
 }
 
 export function normalizeAddressList(
-  inputs: MailtrapAddressParam[]
+  inputs: MailtrapAddressParam[] | string
 ): Address[] {
-  return inputs.flatMap((item) => {
-    if (typeof item === "string") {
-      const e = item.trim();
-      return e.length > 0 ? [{ email: e }] : [];
-    }
-    const e = item.email?.trim() ?? "";
-    if (e.length === 0) {
-      return [];
-    }
-    const addr: Address = { email: e };
-    const name = item.name?.trim();
-    if (name) {
-      addr.name = name;
-    }
-    return [addr];
-  });
+  return normalizeAddressValue(inputs);
 }
 
 export function normalizeToRecipients(
   to: MailtrapAddressParam | MailtrapAddressParam[]
 ): Address[] {
-  const list = Array.isArray(to) ? to : [to];
-  return normalizeAddressList(list);
+  return normalizeAddressValue(to);
 }
 
 /**
- * Sandbox `to` as comma-separated string (plain emails) or an array of address params.
+ * Sandbox `to` as comma-separated string (plain emails) or an array of address
+ * params (or a JSON-stringified form of the latter).
  * Returns an empty array if no valid recipients are present; callers are responsible
  * for validating that the combined to/cc/bcc has at least one recipient.
  */
 export function parseSandboxTo(to: string | MailtrapAddressParam[]): Address[] {
-  if (typeof to === "string") {
-    const toEmails = to
+  const revived = reviveJsonString(to);
+  if (typeof revived === "string") {
+    const toEmails = revived
       .split(",")
       .map((email) => email.trim())
       .filter((email) => email.length > 0)
       .filter((email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email));
     return toEmails.map((email) => ({ email }));
   }
-  return normalizeAddressList(to);
+  return normalizeAddressValue(revived);
 }


### PR DESCRIPTION
## Problem

Customer report (Claude Desktop Cowork on Windows, mailtrap-mcp v0.4.3): `send-email` and `send-sandbox-email` fail when `to` is an array or object, while a plain string works.

Root cause (reproduced): Claude Desktop's MCP schema sanitizer strips property-level `oneOf` unions, reducing the `to`/`from` schemas to `{}`. The argument then arrives at the server as a **JSON-stringified string**:

- Sandbox `to` as a stringified object array fails the comma-split email regex → zero recipients → `"Provide at least one recipient via 'to', 'cc', or 'bcc'"`
- A stringified string array is treated as one literal address → Mailtrap API rejects `"address is invalid in 'to' 0"`
- `cc`/`bcc` kept working because their property-level schema is a plain `type: "array"` — only their items' `oneOf` was stripped

## Fix

1. **Combinator-free schemas.** Shared fragments in `src/tools/schemas/mailtrapAddressParam.ts` (`from`, `to` list, `cc`, `bcc`) replace the `oneOf` unions across `send-email`, `send-sandbox-email`, and both batch send schemas. The canonical shape is an array of `{ email, name? }` objects — the same property-level shape that already survived sanitization for `cc`/`bcc`.
2. **Defensive revival in the normalizers.** String address values that look like JSON arrays/objects are parsed back before normalization (`src/utils/mailtrapAddresses.ts`), so even a client that stringifies arguments gets correct recipients. Nested arrays are dropped (only one list level is valid), keeping the normalizer flat and stack-safe.
3. **Scoped address errors.** `toMailtrapAddress` takes an optional context, so failures read e.g. `Invalid address in requests[2] 'reply_to': …` instead of a generic message.

**Non-breaking:** the runtime still accepts every previously documented input format (bare strings, comma-separated sandbox strings, mixed arrays); only the advertised schema shape changed. README updated to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email tools now accept recipient details as objects or email strings, including JSON-formatted inputs.
  * Sandbox email recipients can be provided as comma-separated email addresses.
  * Improved handling of optional CC, BCC, and reply-to addresses.

* **Bug Fixes**
  * Invalid or empty recipient entries are filtered more consistently.
  * Address validation now provides clearer error context.

* **Documentation**
  * Updated email tool documentation to describe supported recipient formats and optional fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->