### PR TITLE
Add inbound_receiving webhook support to webhook tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,8 +139,8 @@ Folders contain inboxes; inboxes receive messages, grouped into threads.
 
 - **list-webhooks**: List all webhooks for the account.
 - **get-webhook**: Get a single webhook by ID. `signing_secret` is not returned (only on create).
-- **create-webhook**: Create a webhook. Response includes `signing_secret` (returned only on creation — must be stored by caller).
-- **update-webhook**: Update a webhook's mutable fields (`url`, `active`, `payload_format`, `event_types`). Immutable: `webhook_type`, `sending_stream`, `domain_id`.
+- **create-webhook**: Create a webhook. Response includes `signing_secret` (returned only on creation — must be stored by caller). `webhook_type` supports `email_sending`, `audit_log`, and `inbound_receiving`; `inbound_inbox_id` optionally scopes an `inbound_receiving` webhook to one inbox (omit to apply to all inboxes).
+- **update-webhook**: Update a webhook's mutable fields (`url`, `active`, `payload_format`, `event_types`, `inbound_inbox_id`). Immutable: `webhook_type`, `sending_stream`, `domain_id`.
 - **delete-webhook**: Permanently delete a webhook by ID. Returns the deleted record.
 
 

--- a/README.md
+++ b/README.md
@@ -643,12 +643,13 @@ Create a webhook. The response includes a `signing_secret` for verifying webhook
 **Parameters:**
 
 - `url` (required): URL Mailtrap will POST webhook events to
-- `webhook_type` (required): `"email_sending"` or `"audit_log"`
+- `webhook_type` (required): `"email_sending"`, `"audit_log"`, or `"inbound_receiving"`
 - `active` (optional, boolean): defaults to `true`
 - `payload_format` (optional): `"json"` or `"jsonlines"`. Defaults to `"json"`
 - `sending_stream` (optional, `email_sending` only): `"transactional"` or `"bulk"`
 - `event_types` (optional, `email_sending` only): array of `delivery`, `soft_bounce`, `bounce`, `suspension`, `unsubscribe`, `open`, `spam_complaint`, `click`, `reject`
 - `domain_id` (optional, `email_sending` only): sending domain ID to scope this webhook to
+- `inbound_inbox_id` (optional, `inbound_receiving` only): ID of the inbound inbox the webhook is linked to; omit to apply to all inboxes in the account
 
 ### update-webhook
 
@@ -661,6 +662,7 @@ Update a webhook's mutable fields. `webhook_type`, `sending_stream`, and `domain
 - `active` (optional, boolean): Enable or disable the webhook
 - `payload_format` (optional): `"json"` or `"jsonlines"`
 - `event_types` (optional, `email_sending` only): array of `delivery`, `soft_bounce`, `bounce`, `suspension`, `unsubscribe`, `open`, `spam_complaint`, `click`, `reject`
+- `inbound_inbox_id` (optional, `inbound_receiving` only): ID of the inbound inbox the webhook is linked to
 
 ### delete-webhook
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -729,7 +729,7 @@ const tools = [
   {
     name: "create-webhook",
     description:
-      "Create a webhook. The response includes a `signing_secret` for verifying webhook payload signatures — this secret is returned only on creation, so store it now.",
+      "Create a webhook. `webhook_type` may be `email_sending`, `audit_log`, or `inbound_receiving`; for `inbound_receiving`, `inbound_inbox_id` is optional (scopes the webhook to one inbox — omit to apply to all inboxes). The response includes a `signing_secret` for verifying webhook payload signatures — this secret is returned only on creation, so store it now.",
     inputSchema: createWebhookSchema,
     handler: createWebhook,
     annotations: {
@@ -739,7 +739,7 @@ const tools = [
   {
     name: "update-webhook",
     description:
-      "Update a webhook's mutable fields (`url`, `active`, `payload_format`, `event_types`). `webhook_type`, `sending_stream`, and `domain_id` cannot be changed after creation.",
+      "Update a webhook's mutable fields (`url`, `active`, `payload_format`, `event_types`, `inbound_inbox_id`). `webhook_type`, `sending_stream`, and `domain_id` cannot be changed after creation.",
     inputSchema: updateWebhookSchema,
     handler: updateWebhook,
     annotations: {

--- a/src/tools/webhooks/__tests__/createWebhook.test.ts
+++ b/src/tools/webhooks/__tests__/createWebhook.test.ts
@@ -75,6 +75,37 @@ describe("createWebhook", () => {
     });
   });
 
+  it("forwards inbound_inbox_id for an inbound_receiving webhook", async () => {
+    mockClient.webhooks.create.mockResolvedValue({
+      data: {
+        id: 44,
+        url: "https://example.com/inbound",
+        active: true,
+        webhook_type: "inbound_receiving",
+        payload_format: "json",
+        inbound_inbox_id: 1001,
+        signing_secret: "whsec_inbound",
+      },
+    });
+
+    const result = await createWebhook({
+      url: "https://example.com/inbound",
+      webhook_type: "inbound_receiving",
+      inbound_inbox_id: 1001,
+    });
+
+    expect(mockClient.webhooks.create).toHaveBeenCalledWith({
+      url: "https://example.com/inbound",
+      webhook_type: "inbound_receiving",
+      inbound_inbox_id: 1001,
+    });
+    expect(result.content[0].text).toContain('"inbound_inbox_id": 1001');
+    expect(result.content[0].text).toContain(
+      '"webhook_type": "inbound_receiving"'
+    );
+    expect(result.isError).toBeUndefined();
+  });
+
   it("surfaces API errors", async () => {
     mockClient.webhooks.create.mockRejectedValue(new Error("url is invalid"));
 

--- a/src/tools/webhooks/__tests__/updateWebhook.test.ts
+++ b/src/tools/webhooks/__tests__/updateWebhook.test.ts
@@ -69,6 +69,25 @@ describe("updateWebhook", () => {
     });
   });
 
+  it("forwards inbound_inbox_id when updating an inbound_receiving webhook", async () => {
+    mockClient.webhooks.update.mockResolvedValue({
+      data: {
+        id: 44,
+        url: "https://example.com/inbound",
+        active: true,
+        webhook_type: "inbound_receiving",
+        payload_format: "json",
+        inbound_inbox_id: 2002,
+      },
+    });
+
+    await updateWebhook({ webhook_id: 44, inbound_inbox_id: 2002 });
+
+    expect(mockClient.webhooks.update).toHaveBeenCalledWith(44, {
+      inbound_inbox_id: 2002,
+    });
+  });
+
   it("surfaces API errors", async () => {
     mockClient.webhooks.update.mockRejectedValue(
       new Error("validation failed")

--- a/src/tools/webhooks/schemas/createWebhook.ts
+++ b/src/tools/webhooks/schemas/createWebhook.ts
@@ -7,9 +7,9 @@ const createWebhookSchema = {
     },
     webhook_type: {
       type: "string",
-      enum: ["email_sending", "audit_log"],
+      enum: ["email_sending", "audit_log", "inbound_receiving"],
       description:
-        "Webhook category. `email_sending` for delivery/open/click/etc events, `audit_log` for account audit events.",
+        "Webhook category. `email_sending` for delivery/open/click/etc events, `audit_log` for account audit events, `inbound_receiving` for inbound inbox events.",
     },
     active: {
       type: "boolean",
@@ -49,6 +49,11 @@ const createWebhookSchema = {
       type: "number",
       description:
         "Sending domain ID to scope this webhook to. Applies only to `email_sending` webhooks.",
+    },
+    inbound_inbox_id: {
+      type: "number",
+      description:
+        "ID of the inbound inbox the webhook is linked to. Applicable only for `inbound_receiving` webhooks; optional — omit to apply to all inboxes in the account.",
     },
   },
   required: ["url", "webhook_type"],

--- a/src/tools/webhooks/schemas/updateWebhook.ts
+++ b/src/tools/webhooks/schemas/updateWebhook.ts
@@ -37,6 +37,11 @@ const updateWebhookSchema = {
       description:
         "Events to subscribe to. Applies only to `email_sending` webhooks.",
     },
+    inbound_inbox_id: {
+      type: "number",
+      description:
+        "ID of the inbound inbox the webhook is linked to. Applicable only for `inbound_receiving` webhooks.",
+    },
   },
   required: ["webhook_id"],
   additionalProperties: false,

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -378,7 +378,7 @@ export interface DeleteSuppressionRequest {
 
 // --- Webhook types ---
 
-export type WebhookType = "email_sending" | "audit_log";
+export type WebhookType = "email_sending" | "audit_log" | "inbound_receiving";
 
 export type WebhookPayloadFormat = "json" | "jsonlines";
 
@@ -403,6 +403,7 @@ export interface Webhook {
   payload_format: WebhookPayloadFormat;
   sending_stream?: WebhookSendingStream | null;
   domain_id?: number | null;
+  inbound_inbox_id?: number | null;
   event_types?: WebhookEventType[];
 }
 
@@ -426,6 +427,7 @@ export interface CreateWebhookRequest {
   sending_stream?: WebhookSendingStream;
   event_types?: WebhookEventType[];
   domain_id?: number;
+  inbound_inbox_id?: number;
 }
 
 export interface UpdateWebhookRequest {
@@ -434,6 +436,7 @@ export interface UpdateWebhookRequest {
   active?: boolean;
   payload_format?: WebhookPayloadFormat;
   event_types?: WebhookEventType[];
+  inbound_inbox_id?: number;
 }
 
 // --- Contact types ---


### PR DESCRIPTION
## Summary

Backfill of the inbound v2 MCP work (#124, merged), which shipped without support for the inbound-receiving webhook. This adds the `inbound_receiving` webhook type and the `inbound_inbox_id` field to the webhook tools.

Per the email-sending OpenAPI spec and the `mailtrap` Node SDK (>=4.8.0):
- `webhook_type` gained the value `inbound_receiving` (alongside `email_sending`, `audit_log`).
- `inbound_inbox_id` (integer, nullable) links a webhook to an inbound inbox — optional; omit to apply the webhook to all inboxes in the account.

## Changes

- **Types** (`src/types/mailtrap.ts`): `WebhookType` now includes `inbound_receiving`; `inbound_inbox_id` added to `Webhook`, `CreateWebhookRequest`, and `UpdateWebhookRequest`.
- **JSON Schemas**: `inbound_receiving` added to the create-webhook `webhook_type` enum; `inbound_inbox_id` (number, optional) added to create-webhook and update-webhook input schemas.
- **Handlers**: no logic change — both already forward validated params; SDK 4.8.0 accepts `inbound_inbox_id` on `Create`/`UpdateWebhookParams`.
- **Docs**: updated tool descriptions in `server.ts`, `README.md`, and `CLAUDE.md`.
- **Tests**: added create/update cases covering `inbound_inbox_id`.

## Notes

- `campaigns` (also present in the SDK's `WebhookType`) was intentionally **not** added — it was never in the schema and is outside this backfill's scope.
