### PR TITLE
Add batch send sandbox email tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ Schema files define a JSON Schema–shaped object for MCP; optional Zod schemas 
 #### Sandbox Testing
 
 - **send-sandbox-email**: Send email in sandbox mode to a test inbox.
+- **batch-send-sandbox-email**: Send a batch of emails in sandbox mode to a test inbox in one call. Same `base` + `requests[]` shape as the transactional/bulk batch tools, plus `test_inbox_id` (falls back to `MAILTRAP_TEST_INBOX_ID`).
 - **get-sandbox-messages**: Get list of messages from the sandbox test inbox.
 - **show-sandbox-email-message**: Show sandbox email message details and content from the sandbox test inbox.
 - **list-sandbox-projects** / **create-sandbox-project** / **get-sandbox-project** / **update-sandbox-project** / **delete-sandbox-project**: Manage sandbox projects (group of inboxes).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ Schema files define a JSON Schema–shaped object for MCP; optional Zod schemas 
 #### Sandbox Testing
 
 - **send-sandbox-email**: Send email in sandbox mode to a test inbox.
-- **batch-send-sandbox-email**: Send a batch of emails in sandbox mode to a test inbox in one call. Same `base` + `requests[]` shape as the transactional/bulk batch tools, plus `test_inbox_id` (falls back to `MAILTRAP_TEST_INBOX_ID`).
+- **batch-send-sandbox-email**: Send a batch of emails in sandbox mode to a test inbox in one call. Same `base` + `requests[]` shape as the transactional/bulk batch tools, plus `sandbox_id` (falls back to `MAILTRAP_SANDBOX_ID`).
 - **get-sandbox-messages**: Get list of messages from the sandbox test inbox.
 - **show-sandbox-email-message**: Show sandbox email message details and content from the sandbox test inbox.
 - **list-sandbox-projects** / **create-sandbox-project** / **get-sandbox-project** / **update-sandbox-project** / **delete-sandbox-project**: Manage sandbox projects (group of inboxes).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Before using this MCP server, you need to:
 **Optional (can be passed as tool parameters instead):**
 
 - `DEFAULT_FROM_EMAIL` - Default sender email when `from` is not provided to send-email, send-sandbox-email, or the batch-send-\* tools (where it fills `base.from`). Enables switching sender per call via the `from` parameter.
-- `MAILTRAP_TEST_INBOX_ID` - Default test inbox ID for sandbox tools when `test_inbox_id` is not provided. Enables switching between inboxes per call via the `test_inbox_id` parameter.
+- `MAILTRAP_TEST_INBOX_ID` - Default test inbox ID for sandbox tools when `test_inbox_id` is not provided. Enables switching between inboxes per call via the `test_inbox_id` parameter. Legacy alias for `MAILTRAP_SANDBOX_ID`, still honored as a fallback.
 - `MAILTRAP_SANDBOX_ID` - Default sandbox ID for sandbox tools when `sandbox_id` is not provided. Enables switching between sandboxes per call via the `sandbox_id` parameter.
 - `MAILTRAP_ORGANIZATION_ID` - Required for organization tools (`list-sub-accounts`, `create-sub-account`).
 - `MAILTRAP_ORGANIZATION_API_TOKEN` - Organization-scoped API token. Required for organization tools (separate from `MAILTRAP_API_TOKEN`).
@@ -364,11 +364,11 @@ Sends a batch of emails to your Mailtrap test inbox in one API call, without del
 
 **Parameters:**
 
-- `test_inbox_id` (optional): Mailtrap test inbox ID. Required unless `MAILTRAP_TEST_INBOX_ID` is set; pass per call to target a specific inbox.
+- `sandbox_id` (optional): Mailtrap sandbox (test inbox) ID. Required unless `MAILTRAP_SANDBOX_ID` is set; pass per call to target a specific sandbox.
 - `base` (optional), `requests` (required): See `batch-send-transactional-email` above.
 
 > [!NOTE]
-> For sandbox tools, provide `test_inbox_id` in the tool call or set the `MAILTRAP_TEST_INBOX_ID` environment variable. You can switch between inboxes per call by passing `test_inbox_id`.
+> For sandbox tools, provide `test_inbox_id` in the tool call or set the `MAILTRAP_TEST_INBOX_ID` environment variable. You can switch between inboxes per call by passing `test_inbox_id`. Tools taking `sandbox_id` use `MAILTRAP_SANDBOX_ID` first.
 
 ### get-sandbox-messages
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Before using this MCP server, you need to:
 **Optional (can be passed as tool parameters instead):**
 
 - `DEFAULT_FROM_EMAIL` - Default sender email when `from` is not provided to send-email, send-sandbox-email, or the batch-send-\* tools (where it fills `base.from`). Enables switching sender per call via the `from` parameter.
-- `MAILTRAP_TEST_INBOX_ID` - Default test inbox ID for sandbox tools when `test_inbox_id` is not provided. Enables switching between inboxes per call via the `test_inbox_id` parameter. Legacy alias for `MAILTRAP_SANDBOX_ID`, still honored as a fallback.
 - `MAILTRAP_SANDBOX_ID` - Default sandbox ID for sandbox tools when `sandbox_id` is not provided. Enables switching between sandboxes per call via the `sandbox_id` parameter.
+- `MAILTRAP_TEST_INBOX_ID` - Default test inbox ID for sandbox tools when `test_inbox_id` is not provided. Enables switching between inboxes per call via the `test_inbox_id` parameter. Legacy alias for `MAILTRAP_SANDBOX_ID`, still honored as a fallback.
 - `MAILTRAP_ORGANIZATION_ID` - Required for organization tools (`list-sub-accounts`, `create-sub-account`).
 - `MAILTRAP_ORGANIZATION_API_TOKEN` - Organization-scoped API token. Required for organization tools (separate from `MAILTRAP_API_TOKEN`).
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Before using this MCP server, you need to:
 **Required Environment Variables:**
 
 - `MAILTRAP_API_TOKEN` - Required for all functionality
-- `MAILTRAP_ACCOUNT_ID` - Required for templates, stats, email logs, sandbox list/show, and sending domains. Optional only for send-email and send-sandbox-email.
+- `MAILTRAP_ACCOUNT_ID` - Required for templates, stats, email logs, sandbox list/show, and sending domains. Optional only for the send tools (send-email, send-sandbox-email, and the batch-send-\* tools).
 
 **Optional (can be passed as tool parameters instead):**
 
-- `DEFAULT_FROM_EMAIL` - Default sender email when `from` is not provided to send-email or send-sandbox-email. Enables switching sender per call via the `from` parameter.
+- `DEFAULT_FROM_EMAIL` - Default sender email when `from` is not provided to send-email, send-sandbox-email, or the batch-send-\* tools (where it fills `base.from`). Enables switching sender per call via the `from` parameter.
 - `MAILTRAP_TEST_INBOX_ID` - Default test inbox ID for sandbox tools when `test_inbox_id` is not provided. Enables switching between inboxes per call via the `test_inbox_id` parameter.
 - `MAILTRAP_SANDBOX_ID` - Default sandbox ID for sandbox tools when `sandbox_id` is not provided. Enables switching between sandboxes per call via the `sandbox_id` parameter.
 - `MAILTRAP_ORGANIZATION_ID` - Required for organization tools (`list-sub-accounts`, `create-sub-account`).
@@ -357,6 +357,15 @@ Sends an email to your Mailtrap test inbox for development and testing purposes.
 - `category` (optional): Email category for tracking. Must be omitted when `template_uuid` is set.
 - `template_uuid` (optional): Use a Mailtrap email template instead of inline content. When set, `subject` / `text` / `html` / `category` must be omitted.
 - `template_variables` (optional): Object of variables substituted into the template referenced by `template_uuid`. Only allowed together with `template_uuid`.
+
+### batch-send-sandbox-email
+
+Sends a batch of emails to your Mailtrap test inbox in one API call, without delivering to real recipients. Same `base` + `requests[]` shape, validation, and inline-vs-template rules as `batch-send-transactional-email` — the difference is that this tool routes the call through the sandbox endpoint for a single test inbox.
+
+**Parameters:**
+
+- `test_inbox_id` (optional): Mailtrap test inbox ID. Required unless `MAILTRAP_TEST_INBOX_ID` is set; pass per call to target a specific inbox.
+- `base` (optional), `requests` (required): See `batch-send-transactional-email` above.
 
 > [!NOTE]
 > For sandbox tools, provide `test_inbox_id` in the tool call or set the `MAILTRAP_TEST_INBOX_ID` environment variable. You can switch between inboxes per call by passing `test_inbox_id`.

--- a/src/server.ts
+++ b/src/server.ts
@@ -336,7 +336,7 @@ const tools = [
   {
     name: "batch-send-sandbox-email",
     description:
-      "Send a batch of emails in sandbox mode to a test inbox in one Mailtrap API call. Shared fields go on `base`; per-recipient overrides go in `requests[]`. Requires `test_inbox_id` or the MAILTRAP_TEST_INBOX_ID env var.",
+      "Send a batch of emails in sandbox mode to a test inbox in one Mailtrap API call. Shared fields go on `base`; per-recipient overrides go in `requests[]`. Requires `sandbox_id` or the MAILTRAP_SANDBOX_ID env var.",
     inputSchema: batchSendSandboxEmailSchema,
     handler: batchSendSandboxEmail,
     annotations: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,6 +35,8 @@ import {
 import {
   sendSandboxEmail,
   sendSandboxEmailSchema,
+  batchSendSandboxEmail,
+  batchSendSandboxEmailSchema,
   getMessages,
   getMessagesSchema,
   showEmailMessage,
@@ -327,6 +329,16 @@ const tools = [
       "Send an email in sandbox mode to a test inbox without delivering to your recipients",
     inputSchema: sendSandboxEmailSchema,
     handler: sendSandboxEmail,
+    annotations: {
+      destructiveHint: false,
+    },
+  },
+  {
+    name: "batch-send-sandbox-email",
+    description:
+      "Send a batch of emails in sandbox mode to a test inbox in one Mailtrap API call. Shared fields go on `base`; per-recipient overrides go in `requests[]`. Requires `test_inbox_id` or the MAILTRAP_TEST_INBOX_ID env var.",
+    inputSchema: batchSendSandboxEmailSchema,
+    handler: batchSendSandboxEmail,
     annotations: {
       destructiveHint: false,
     },

--- a/src/tools/sandbox/__tests__/batchSendSandboxEmail.test.ts
+++ b/src/tools/sandbox/__tests__/batchSendSandboxEmail.test.ts
@@ -1,0 +1,123 @@
+import batchSendSandboxEmail from "../batchSendSandboxEmail";
+import { getSandboxClient } from "../../../client";
+
+const mockClient = {
+  batchSend: jest.fn(),
+};
+
+jest.mock("../../../client", () => ({
+  getSandboxClient: jest.fn(() => mockClient),
+}));
+
+describe("batchSendSandboxEmail", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getSandboxClient as jest.Mock).mockReturnValue(mockClient);
+    process.env = { ...originalEnv };
+    delete process.env.MAILTRAP_SANDBOX_ID;
+    delete process.env.MAILTRAP_TEST_INBOX_ID;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("uses the sandbox client for the given inbox and forwards the SDK payload", async () => {
+    mockClient.batchSend.mockResolvedValue({
+      success: true,
+      responses: [{ success: true, message_ids: ["m-1"] }],
+    });
+
+    const result = await batchSendSandboxEmail({
+      test_inbox_id: 4242,
+      base: {
+        from: { email: "sender@example.com", name: "Sender" },
+        subject: "Sandbox hello",
+        text: "Hello sandbox",
+      },
+      requests: [{ to: "alice@example.com" }],
+    });
+
+    expect(getSandboxClient).toHaveBeenCalledWith(4242);
+    expect(mockClient.batchSend).toHaveBeenCalledWith({
+      base: {
+        from: { email: "sender@example.com", name: "Sender" },
+        subject: "Sandbox hello",
+        text: "Hello sandbox",
+      },
+      requests: [{ to: [{ email: "alice@example.com" }] }],
+    });
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("does not forward test_inbox_id into the SDK payload", async () => {
+    mockClient.batchSend.mockResolvedValue({ success: true, responses: [] });
+
+    await batchSendSandboxEmail({
+      test_inbox_id: 4242,
+      base: { from: "sender@example.com", subject: "Hi", text: "x" },
+      requests: [{ to: "alice@example.com" }],
+    });
+
+    const payload = mockClient.batchSend.mock.calls[0][0];
+    expect(payload.base).not.toHaveProperty("test_inbox_id");
+    expect(payload).not.toHaveProperty("test_inbox_id");
+  });
+
+  it("falls back to MAILTRAP_TEST_INBOX_ID when test_inbox_id is omitted", async () => {
+    process.env.MAILTRAP_TEST_INBOX_ID = "777";
+    mockClient.batchSend.mockResolvedValue({ success: true, responses: [] });
+
+    const result = await batchSendSandboxEmail({
+      base: { from: "sender@example.com", subject: "Hi", text: "x" },
+      requests: [{ to: "alice@example.com" }],
+    });
+
+    expect(getSandboxClient).toHaveBeenCalledWith(777);
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("errors when no inbox is configured", async () => {
+    const result = await batchSendSandboxEmail({
+      base: { from: "sender@example.com", subject: "Hi", text: "x" },
+      requests: [{ to: "alice@example.com" }],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to batch send sandbox email: Provide test_inbox_id or set MAILTRAP_TEST_INBOX_ID environment variable for sandbox mode"
+    );
+    expect(mockClient.batchSend).not.toHaveBeenCalled();
+  });
+
+  it("propagates payload validation errors", async () => {
+    const result = await batchSendSandboxEmail({
+      test_inbox_id: 4242,
+      base: { from: "sender@example.com", subject: "Hi", text: "x" },
+      requests: [{}],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(
+      "Failed to batch send sandbox email: requests[0]: provide at least one recipient"
+    );
+    expect(mockClient.batchSend).not.toHaveBeenCalled();
+  });
+
+  it("surfaces API errors with a sandbox-specific prefix", async () => {
+    mockClient.batchSend.mockRejectedValue(new Error("inbox is full"));
+
+    const result = await batchSendSandboxEmail({
+      test_inbox_id: 4242,
+      base: { from: "sender@example.com", subject: "Hi", text: "x" },
+      requests: [{ to: "alice@example.com" }],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      "Failed to batch send sandbox email: inbox is full"
+    );
+  });
+});

--- a/src/tools/sandbox/__tests__/batchSendSandboxEmail.test.ts
+++ b/src/tools/sandbox/__tests__/batchSendSandboxEmail.test.ts
@@ -31,7 +31,7 @@ describe("batchSendSandboxEmail", () => {
     });
 
     const result = await batchSendSandboxEmail({
-      test_inbox_id: 4242,
+      sandbox_id: 4242,
       base: {
         from: { email: "sender@example.com", name: "Sender" },
         subject: "Sandbox hello",
@@ -52,22 +52,22 @@ describe("batchSendSandboxEmail", () => {
     expect(result.isError).toBeUndefined();
   });
 
-  it("does not forward test_inbox_id into the SDK payload", async () => {
+  it("does not forward sandbox_id into the SDK payload", async () => {
     mockClient.batchSend.mockResolvedValue({ success: true, responses: [] });
 
     await batchSendSandboxEmail({
-      test_inbox_id: 4242,
+      sandbox_id: 4242,
       base: { from: "sender@example.com", subject: "Hi", text: "x" },
       requests: [{ to: "alice@example.com" }],
     });
 
     const payload = mockClient.batchSend.mock.calls[0][0];
-    expect(payload.base).not.toHaveProperty("test_inbox_id");
-    expect(payload).not.toHaveProperty("test_inbox_id");
+    expect(payload.base).not.toHaveProperty("sandbox_id");
+    expect(payload).not.toHaveProperty("sandbox_id");
   });
 
-  it("falls back to MAILTRAP_TEST_INBOX_ID when test_inbox_id is omitted", async () => {
-    process.env.MAILTRAP_TEST_INBOX_ID = "777";
+  it("falls back to MAILTRAP_SANDBOX_ID when sandbox_id is omitted", async () => {
+    process.env.MAILTRAP_SANDBOX_ID = "777";
     mockClient.batchSend.mockResolvedValue({ success: true, responses: [] });
 
     const result = await batchSendSandboxEmail({
@@ -79,7 +79,28 @@ describe("batchSendSandboxEmail", () => {
     expect(result.isError).toBeUndefined();
   });
 
-  it("errors when no inbox is configured", async () => {
+  it("falls back to the legacy MAILTRAP_TEST_INBOX_ID, but MAILTRAP_SANDBOX_ID wins", async () => {
+    process.env.MAILTRAP_TEST_INBOX_ID = "777";
+    mockClient.batchSend.mockResolvedValue({ success: true, responses: [] });
+
+    await batchSendSandboxEmail({
+      base: { from: "sender@example.com", subject: "Hi", text: "x" },
+      requests: [{ to: "alice@example.com" }],
+    });
+
+    expect(getSandboxClient).toHaveBeenCalledWith(777);
+
+    process.env.MAILTRAP_SANDBOX_ID = "888";
+
+    await batchSendSandboxEmail({
+      base: { from: "sender@example.com", subject: "Hi", text: "x" },
+      requests: [{ to: "alice@example.com" }],
+    });
+
+    expect(getSandboxClient).toHaveBeenLastCalledWith(888);
+  });
+
+  it("errors when no sandbox is configured", async () => {
     const result = await batchSendSandboxEmail({
       base: { from: "sender@example.com", subject: "Hi", text: "x" },
       requests: [{ to: "alice@example.com" }],
@@ -87,14 +108,14 @@ describe("batchSendSandboxEmail", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toBe(
-      "Failed to batch send sandbox email: Provide test_inbox_id or set MAILTRAP_TEST_INBOX_ID environment variable for sandbox mode"
+      "Failed to batch send sandbox email: Provide sandbox_id or set MAILTRAP_SANDBOX_ID environment variable for sandbox mode"
     );
     expect(mockClient.batchSend).not.toHaveBeenCalled();
   });
 
   it("propagates payload validation errors", async () => {
     const result = await batchSendSandboxEmail({
-      test_inbox_id: 4242,
+      sandbox_id: 4242,
       base: { from: "sender@example.com", subject: "Hi", text: "x" },
       requests: [{}],
     });
@@ -110,7 +131,7 @@ describe("batchSendSandboxEmail", () => {
     mockClient.batchSend.mockRejectedValue(new Error("inbox is full"));
 
     const result = await batchSendSandboxEmail({
-      test_inbox_id: 4242,
+      sandbox_id: 4242,
       base: { from: "sender@example.com", subject: "Hi", text: "x" },
       requests: [{ to: "alice@example.com" }],
     });

--- a/src/tools/sandbox/batchSendSandboxEmail.ts
+++ b/src/tools/sandbox/batchSendSandboxEmail.ts
@@ -9,15 +9,11 @@ import {
 import resolveSandboxId from "./utils/resolveSandboxId";
 
 async function batchSendSandboxEmail({
-  test_inbox_id,
+  sandbox_id,
   ...body
 }: BatchSendSandboxEmailToolRequest): Promise<ToolResponse> {
   try {
-    const inboxId = resolveSandboxId(
-      test_inbox_id,
-      "test_inbox_id",
-      "MAILTRAP_TEST_INBOX_ID"
-    );
+    const inboxId = resolveSandboxId(sandbox_id);
 
     const payload = buildBatchPayload(body);
 

--- a/src/tools/sandbox/batchSendSandboxEmail.ts
+++ b/src/tools/sandbox/batchSendSandboxEmail.ts
@@ -1,0 +1,36 @@
+import { getSandboxClient } from "../../client";
+import { BatchSendSandboxEmailToolRequest } from "../../types/mailtrap";
+import buildBatchPayload from "../sendEmail/buildBatchPayload";
+import {
+  buildErrorResponse,
+  buildSuccessResponse,
+  ToolResponse,
+} from "../utils/responses";
+import resolveSandboxId from "./utils/resolveSandboxId";
+
+async function batchSendSandboxEmail({
+  test_inbox_id,
+  ...body
+}: BatchSendSandboxEmailToolRequest): Promise<ToolResponse> {
+  try {
+    const inboxId = resolveSandboxId(
+      test_inbox_id,
+      "test_inbox_id",
+      "MAILTRAP_TEST_INBOX_ID"
+    );
+
+    const payload = buildBatchPayload(body);
+
+    const mailtrap = getSandboxClient(inboxId);
+
+    const response = await mailtrap.batchSend(
+      payload as unknown as Parameters<typeof mailtrap.batchSend>[0]
+    );
+
+    return buildSuccessResponse(JSON.stringify(response, null, 2));
+  } catch (error) {
+    return buildErrorResponse("batch send sandbox email", error);
+  }
+}
+
+export default batchSendSandboxEmail;

--- a/src/tools/sandbox/index.ts
+++ b/src/tools/sandbox/index.ts
@@ -1,5 +1,7 @@
 import sendSandboxEmailSchema from "./schemas/sendSandboxEmail";
 import sendSandboxEmail from "./sendSandboxEmail";
+import batchSendSandboxEmailSchema from "./schemas/batchSendSandboxEmail";
+import batchSendSandboxEmail from "./batchSendSandboxEmail";
 import getMessagesSchema from "./schemas/getMessages";
 import getMessages from "./getSandboxMessages";
 import showEmailMessageSchema from "./schemas/showEmailMessage";
@@ -58,6 +60,8 @@ import getSandboxAttachment from "./getSandboxAttachment";
 export {
   sendSandboxEmailSchema,
   sendSandboxEmail,
+  batchSendSandboxEmailSchema,
+  batchSendSandboxEmail,
   getMessagesSchema,
   getMessages,
   showEmailMessageSchema,

--- a/src/tools/sandbox/schemas/batchSendSandboxEmail.ts
+++ b/src/tools/sandbox/schemas/batchSendSandboxEmail.ts
@@ -3,10 +3,10 @@ import batchSendStreamEmailSchema from "../../sendEmail/schemas/batchSendStreamE
 const batchSendSandboxEmailSchema = {
   ...batchSendStreamEmailSchema,
   properties: {
-    test_inbox_id: {
+    sandbox_id: {
       type: "number",
       description:
-        "Mailtrap test inbox ID. Optional if MAILTRAP_TEST_INBOX_ID env var is set. Use to target a specific inbox.",
+        "Mailtrap sandbox (test inbox) ID. Optional if MAILTRAP_SANDBOX_ID env var is set. Use to target a specific sandbox.",
     },
     ...batchSendStreamEmailSchema.properties,
   },

--- a/src/tools/sandbox/schemas/batchSendSandboxEmail.ts
+++ b/src/tools/sandbox/schemas/batchSendSandboxEmail.ts
@@ -1,0 +1,15 @@
+import batchSendStreamEmailSchema from "../../sendEmail/schemas/batchSendStreamEmail";
+
+const batchSendSandboxEmailSchema = {
+  ...batchSendStreamEmailSchema,
+  properties: {
+    test_inbox_id: {
+      type: "number",
+      description:
+        "Mailtrap test inbox ID. Optional if MAILTRAP_TEST_INBOX_ID env var is set. Use to target a specific inbox.",
+    },
+    ...batchSendStreamEmailSchema.properties,
+  },
+};
+
+export default batchSendSandboxEmailSchema;

--- a/src/tools/sandbox/utils/resolveSandboxId.ts
+++ b/src/tools/sandbox/utils/resolveSandboxId.ts
@@ -3,27 +3,22 @@
  * MAILTRAP_SANDBOX_ID environment variable (or the legacy MAILTRAP_TEST_INBOX_ID
  * env var, kept for backward compatibility). Throws if neither is set or if
  * the resolved value is not a finite number.
- *
- * `paramName`/`envName` only shape the error messages, so send-family tools
- * (which expose `test_inbox_id`) report the parameter the caller actually passes.
  */
-function resolveSandboxId(
-  sandboxId: number | undefined,
-  paramName = "sandbox_id",
-  envName = "MAILTRAP_SANDBOX_ID"
-): number {
+function resolveSandboxId(sandboxId: number | undefined): number {
   const raw =
     sandboxId ??
     process.env.MAILTRAP_SANDBOX_ID ??
     process.env.MAILTRAP_TEST_INBOX_ID;
   if (raw === undefined || raw === null || raw === "") {
     throw new Error(
-      `Provide ${paramName} or set ${envName} environment variable for sandbox mode`
+      "Provide sandbox_id or set MAILTRAP_SANDBOX_ID environment variable for sandbox mode"
     );
   }
   const resolved = Number(raw);
   if (!Number.isFinite(resolved)) {
-    throw new Error(`${paramName} (or ${envName}) must be a valid number`);
+    throw new Error(
+      "sandbox_id (or MAILTRAP_SANDBOX_ID) must be a valid number"
+    );
   }
   return resolved;
 }

--- a/src/tools/sandbox/utils/resolveSandboxId.ts
+++ b/src/tools/sandbox/utils/resolveSandboxId.ts
@@ -3,22 +3,27 @@
  * MAILTRAP_SANDBOX_ID environment variable (or the legacy MAILTRAP_TEST_INBOX_ID
  * env var, kept for backward compatibility). Throws if neither is set or if
  * the resolved value is not a finite number.
+ *
+ * `paramName`/`envName` only shape the error messages, so send-family tools
+ * (which expose `test_inbox_id`) report the parameter the caller actually passes.
  */
-function resolveSandboxId(sandboxId: number | undefined): number {
+function resolveSandboxId(
+  sandboxId: number | undefined,
+  paramName = "sandbox_id",
+  envName = "MAILTRAP_SANDBOX_ID"
+): number {
   const raw =
     sandboxId ??
     process.env.MAILTRAP_SANDBOX_ID ??
     process.env.MAILTRAP_TEST_INBOX_ID;
   if (raw === undefined || raw === null || raw === "") {
     throw new Error(
-      "Provide sandbox_id or set MAILTRAP_SANDBOX_ID environment variable for sandbox mode"
+      `Provide ${paramName} or set ${envName} environment variable for sandbox mode`
     );
   }
   const resolved = Number(raw);
   if (!Number.isFinite(resolved)) {
-    throw new Error(
-      "sandbox_id (or MAILTRAP_SANDBOX_ID) must be a valid number"
-    );
+    throw new Error(`${paramName} (or ${envName}) must be a valid number`);
   }
   return resolved;
 }

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -82,6 +82,11 @@ export interface BatchSendEmailToolRequest {
   requests: BatchSendEmailRequest[];
 }
 
+export interface BatchSendSandboxEmailToolRequest
+  extends BatchSendEmailToolRequest {
+  test_inbox_id?: number;
+}
+
 export interface CreateTemplateRequest {
   name: string;
   subject: string;

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -84,7 +84,7 @@ export interface BatchSendEmailToolRequest {
 
 export interface BatchSendSandboxEmailToolRequest
   extends BatchSendEmailToolRequest {
-  test_inbox_id?: number;
+  sandbox_id?: number;
 }
 
 export interface CreateTemplateRequest {


### PR DESCRIPTION
## Summary

The `mailtrap` SDK exposes `batchSend` against all three sending streams, but the MCP server only wired up two of them. The send surface is a 3×2 grid (transactional / bulk / sandbox × single `send` / `batchSend`), and the sandbox×batch cell was empty:

| stream | single `send()` | `batchSend()` |
|---|---|---|
| transactional | `send-email` | `batch-send-transactional-email` |
| bulk | — | `batch-send-bulk-email` |
| sandbox | `send-sandbox-email` | **`batch-send-sandbox-email`** (this PR) |

Registers one new tool, `batch-send-sandbox-email`, so sandbox users can batch in a single API call instead of looping `send-sandbox-email`.

## Changes

- **Tool** (`src/tools/sandbox/batchSendSandboxEmail.ts`): resolves the sandbox, builds the payload, posts via a sandbox client. `buildBatchPayload`, `getSandboxClient`, and `resolveSandboxId` were already stream-agnostic, so no new client, payload, or resolver logic was needed — the SDK routes to `TESTING_ENDPOINT/api/batch/{inboxId}` on its own.
- **Schema** (`src/tools/sandbox/schemas/batchSendSandboxEmail.ts`): the shared batch schema plus `sandbox_id`. Built by spreading into a **fresh** `properties` object — all three batch tools re-export one shared schema object, so an in-place edit would leak `sandbox_id` into the transactional and bulk tools.
- **Types** (`src/types/mailtrap.ts`): `BatchSendSandboxEmailToolRequest` extends the existing batch request with `sandbox_id`.
- **Docs**: tool description in `server.ts`, plus `README.md` and `CLAUDE.md`. Also corrected the `MAILTRAP_ACCOUNT_ID` / `DEFAULT_FROM_EMAIL` notes, which listed only the single-send tools but apply to the batch tools too, and flagged `MAILTRAP_TEST_INBOX_ID` as the legacy alias it is.
- **Tests**: 7 cases — payload forwarding, `sandbox_id` not leaking into the SDK payload, `MAILTRAP_SANDBOX_ID` fallback, legacy `MAILTRAP_TEST_INBOX_ID` fallback and its precedence, missing-sandbox error, validation passthrough, API error prefix.

## Notes

- Named `batch-send-sandbox-email`, **not** "bulk sandbox": the SDK throws `BULK_SANDBOX_INCOMPATIBLE` when `bulk` and `sandbox` are both set, so that combination cannot exist. The axis these tools vary on is the stream.
- Exposes `sandbox_id`, not `test_inbox_id`. `MAILTRAP_TEST_INBOX_ID` is a legacy alias for `MAILTRAP_SANDBOX_ID`, and a new tool shouldn't advertise it — the schema description is what the model reads when deciding how to call the tool, and the error message is what a user sees when nothing is configured. Existing configs still resolve via `resolveSandboxId`'s `MAILTRAP_SANDBOX_ID ?? MAILTRAP_TEST_INBOX_ID` fallback, which is covered by a test. This also means the tool needs no changes to `resolveSandboxId` itself, so the PR doesn't touch a helper shared by 14 other tools.
- Returns raw JSON like the sibling batch tools rather than `send-sandbox-email`'s human-readable summary, which would discard `batchSend`'s per-request `errors[]`.
- Accepts any of `to`/`cc`/`bcc` rather than requiring `to`, matching `buildBatchPayload`'s actual behaviour over the SDK's stricter type.
- `attachments` remains unsupported here, consistent with the four existing send tools. The SDK accepts it on batch `base`, each `requests[]` entry, and single `Mail`, but every MCP send schema omits it under `additionalProperties: false` — worth its own ticket rather than a one-off divergence.

## Follow-up (not in this PR)

`send-sandbox-email`, `get-sandbox-messages`, `show-sandbox-email-message`, and `get-sandbox-inbox` predate `resolveSandboxId` and inline their own env lookup, reading only the legacy `MAILTRAP_TEST_INBOX_ID` with no `MAILTRAP_SANDBOX_ID` fallback. So a config with only `MAILTRAP_SANDBOX_ID` set works for this new tool but errors on those four. Routing them through `resolveSandboxId` is a clean separate change — their existing error strings already match the helper's output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added batch email sending to Mailtrap test inboxes through the `batch-send-sandbox-email` tool.
  - Supports shared and recipient-specific email fields, sandbox ID selection, and environment-based fallback.
  - Includes input validation and clear success or error responses.

- **Documentation**
  - Updated setup and tool documentation with sandbox routing, configuration, parameters, supported fields, and validation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
